### PR TITLE
Improve TypeScript watch mode

### DIFF
--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -21,7 +21,6 @@
     "mds-api-authorizer": "0.1.0"
   },
   "devDependencies": {
-    "@types/uuid": "3.4.4",
     "mds-test-data": "0.1.0"
   },
   "license": "Apache-2.0"

--- a/aws-lambda/api-gateway-authorizer/tsconfig.json
+++ b/aws-lambda/api-gateway-authorizer/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": []
+  "references": [{ "path": "../../packages/mds-api-authorizer" }, { "path": "../../packages/mds-test-data" }]
 }

--- a/aws-lambda/aws-serverless-express-handler/tsconfig.json
+++ b/aws-lambda/aws-serverless-express-handler/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-utils" }, { "path": "../api-gateway-authorizer" }]
+  "references": [
+    { "path": "../../aws-lambda/aws-utils" },
+    { "path": "../../aws-lambda/api-gateway-authorizer" },
+    { "path": "../../packages/mds-api-server" }
+  ]
 }

--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -9,11 +9,13 @@
     "bundle": "webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "deploy:us-east-2": "aws lambda update-function-code --region us-east-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
     "deploy:us-west-2": "aws lambda update-function-code --region us-west-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "exit 0"
+    "test:unit": "exit 0",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -23,10 +23,9 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "@aws-lambda/aws-serverless-express-handler": "0.1.0",
-    "mds-agency": "0.0.1"
-  },
-  "devDependencies": {
+    "mds-agency": "0.0.1",
     "mds-api-server": "0.1.0"
   },
+  "devDependencies": {},
   "license": "Apache-2.0"
 }

--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-agency/tsconfig.json
+++ b/aws-lambda/mds-agency/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-serverless-express-handler" }],
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler" },
+    { "path": "../../packages/mds-agency" },
+    { "path": "../../packages/mds-api-server" }
+  ],
   "include": ["index.ts"]
 }

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -9,11 +9,13 @@
     "bundle": "webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "deploy:us-east-2": "aws lambda update-function-code --region us-east-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
     "deploy:us-west-2": "aws lambda update-function-code --region us-west-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "exit 0"
+    "test:unit": "exit 0",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -23,10 +23,9 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "@aws-lambda/aws-serverless-express-handler": "0.1.0",
+    "mds-api-server": "0.1.0",
     "mds-audit": "0.1.12"
   },
-  "devDependencies": {
-    "mds-api-server": "0.1.0"
-  },
+  "devDependencies": {},
   "license": "Apache-2.0"
 }

--- a/aws-lambda/mds-audit/tsconfig.json
+++ b/aws-lambda/mds-audit/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-serverless-express-handler" }],
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-audit" }
+  ],
   "include": ["index.ts"]
 }

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -9,11 +9,13 @@
     "bundle": "webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "deploy:us-east-2": "aws lambda update-function-code --region us-east-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
     "deploy:us-west-2": "aws lambda update-function-code --region us-west-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "exit 0"
+    "test:unit": "exit 0",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -23,10 +23,9 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "@aws-lambda/aws-serverless-express-handler": "0.1.0",
+    "mds-api-server": "0.1.0",
     "mds-compliance": "0.1.1"
   },
-  "devDependencies": {
-    "mds-api-server": "0.1.0"
-  },
+  "devDependencies": {},
   "license": "Apache-2.0"
 }

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-compliance/tsconfig.json
+++ b/aws-lambda/mds-compliance/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-serverless-express-handler" }],
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-compliance" }
+  ],
   "include": ["index.ts"]
 }

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -9,11 +9,13 @@
     "bundle": "webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "deploy:us-east-2": "aws lambda update-function-code --region us-east-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
     "deploy:us-west-2": "aws lambda update-function-code --region us-west-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "exit 0"
+    "test:unit": "exit 0",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -23,10 +23,9 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "@aws-lambda/aws-serverless-express-handler": "0.1.0",
+    "mds-api-server": "0.1.0",
     "mds-daily": "0.0.1"
   },
-  "devDependencies": {
-    "mds-api-server": "0.1.0"
-  },
+  "devDependencies": {},
   "license": "Apache-2.0"
 }

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-daily/tsconfig.json
+++ b/aws-lambda/mds-daily/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-serverless-express-handler" }],
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-daily" }
+  ],
   "include": ["index.ts"]
 }

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -9,11 +9,13 @@
     "bundle": "webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "deploy:us-east-2": "aws lambda update-function-code --region us-east-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
     "deploy:us-west-2": "aws lambda update-function-code --region us-west-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "exit 0"
+    "test:unit": "exit 0",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -23,10 +23,9 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "@aws-lambda/aws-serverless-express-handler": "0.1.0",
+    "mds-api-server": "0.1.0",
     "mds-policy": "0.0.1"
   },
-  "devDependencies": {
-    "mds-api-server": "0.1.0"
-  },
+  "devDependencies": {},
   "license": "Apache-2.0"
 }

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-policy/tsconfig.json
+++ b/aws-lambda/mds-policy/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-serverless-express-handler" }],
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-policy" }
+  ],
   "include": ["index.ts"]
 }

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -9,11 +9,13 @@
     "bundle": "webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "deploy:us-east-2": "aws lambda update-function-code --region us-east-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
     "deploy:us-west-2": "aws lambda update-function-code --region us-west-2 --zip-file fileb://dist/${npm_package_name}.zip --function-name",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "exit 0"
+    "test:unit": "exit 0",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' ==ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -23,10 +23,9 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "@aws-lambda/aws-serverless-express-handler": "0.1.0",
+    "mds-api-server": "0.1.0",
     "mds-provider": "1.0.0"
   },
-  "devDependencies": {
-    "mds-api-server": "0.1.0"
-  },
+  "devDependencies": {},
   "license": "Apache-2.0"
 }

--- a/aws-lambda/mds-provider/tsconfig.json
+++ b/aws-lambda/mds-provider/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../aws-serverless-express-handler" }],
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-provider" }
+  ],
   "include": ["index.ts"]
 }

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -26,10 +26,12 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsc --build .",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts"
+    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -10,18 +10,20 @@
     "jsonwebtoken": "8.5.1",
     "jwt-decode": "2.2.0",
     "ladot-service-areas": "0.1.0",
+    "mds-api-helpers": "0.1.0",
     "mds-api-server": "0.1.0",
     "mds-cache": "0.1.0",
     "mds-db": "0.1.0",
     "mds-enums": "0.1.0",
-    "mds-api-helpers": "0.1.0",
     "mds-logger": "0.1.0",
     "mds-providers": "0.1.0",
     "mds-stream": "0.1.0",
     "mds-utils": "0.1.0",
     "uuid": "3.3.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mds-test-data": "0.1.0"
+  },
   "main": "dist/api.js",
   "types": "dist/api.d.ts",
   "scripts": {

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -31,7 +31,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -31,7 +31,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-agency/tsconfig.json
+++ b/packages/mds-agency/tsconfig.json
@@ -4,15 +4,15 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../mds-api-server" },
-    { "path": "../mds-cache" },
-    { "path": "../mds-db" },
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-providers" },
-    { "path": "../mds-stream" },
-    { "path": "../mds-test-data" },
-    { "path": "../mds-utils" },
-    { "path": "../mds-api-helpers" }
+    { "path": "../../packages/mds-api-helpers" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-cache" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-providers" },
+    { "path": "../../packages/mds-stream" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-utils" }
   ]
 }

--- a/packages/mds-api-authorizer/tsconfig.json
+++ b/packages/mds-api-authorizer/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../mds-test-data" }]
+  "references": [{ "path": "../../packages/mds-test-data" }]
 }

--- a/packages/mds-api-helpers/package.json
+++ b/packages/mds-api-helpers/package.json
@@ -10,10 +10,10 @@
   "author": "City of Los Angeles",
   "license": "Apache-2.0",
   "dependencies": {
-    "mds-utils": "0.1.0",
-    "mds-db": "0.1.0",
+    "express": "4.17.1",
     "mds-cache": "0.1.0",
-    "express": "4.17.1"
+    "mds-db": "0.1.0",
+    "mds-utils": "0.1.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mds-api-helpers/tsconfig.json
+++ b/packages/mds-api-helpers/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../mds-utils" }, { "path": "../mds-cache" }]
+  "references": [
+    { "path": "../../packages/mds-cache" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-utils" }
+  ]
 }

--- a/packages/mds-api-server/tsconfig.json
+++ b/packages/mds-api-server/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../mds-api-authorizer" }, { "path": "../mds-utils" }, { "path": "../mds-test-data" }]
+  "references": [
+    { "path": "../../packages/mds-api-authorizer" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-utils" }
+  ]
 }

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -24,17 +24,18 @@
     "@hapi/joi": "15.1.0",
     "express": "4.17.1",
     "mds-api-authorizer": "0.1.0",
-    "mds-api-server": "0.1.0",
     "mds-api-helpers": "0.1.0",
+    "mds-api-server": "0.1.0",
     "mds-cache": "0.1.0",
     "mds-db": "0.1.0",
     "mds-enums": "0.1.0",
     "mds-logger": "0.1.0",
     "mds-providers": "0.1.0",
-    "mds-test-data": "0.1.0",
     "mds-utils": "0.1.0",
     "uuid": "3.3.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mds-test-data": "0.1.0"
+  },
   "license": "Apache-2.0"
 }

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -12,7 +12,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -7,11 +7,13 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsc --build .",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts"
+    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds",

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -12,7 +12,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/packages/mds-audit/tsconfig.json
+++ b/packages/mds-audit/tsconfig.json
@@ -5,15 +5,16 @@
     "rootDir": "src"
   },
   "references": [
-    { "path": "../mds-api-authorizer" },
-    { "path": "../mds-api-server" },
-    { "path": "../mds-db" },
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-test-data" },
-    { "path": "../mds-providers" },
-    { "path": "../mds-utils" },
-    { "path": "../mds-api-helpers" }
+    { "path": "../../packages/mds-api-authorizer" },
+    { "path": "../../packages/mds-api-helpers" },
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-cache" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-providers" },
+    { "path": "../../packages/mds-utils" }
   ],
   "include": ["./src/*"]
 }

--- a/packages/mds-cache/package.json
+++ b/packages/mds-cache/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "bluebird": "3.5.5",
     "flat": "4.1.0",
-    "mds-logger": "0.1.0",
     "mds-enums": "0.1.0",
+    "mds-logger": "0.1.0",
     "mds-utils": "0.1.0",
     "redis": "2.8.0"
   },

--- a/packages/mds-cache/tsconfig.json
+++ b/packages/mds-cache/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../mds-logger" }, { "path": "../mds-enums" }, { "path": "../mds-utils" }]
+  "references": [
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-utils" }
+  ]
 }

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -11,7 +11,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -31,7 +31,7 @@
     "mds-enums": "0.1.0",
     "mds-logger": "0.1.0",
     "mds-stream": "0.1.0",
-    "mds-test-data": "0.1.0",
+    "mds-utils": "0.1.0",
     "moment-timezone": "0.5.25",
     "uuid4": "1.1.4",
     "yargs": "13.2.4"
@@ -39,6 +39,7 @@
   "devDependencies": {
     "mds-agency": "0.0.1",
     "mds-policy": "0.0.1",
-    "mds-provider": "1.0.0"
+    "mds-provider": "1.0.0",
+    "mds-test-data": "0.1.0"
   }
 }

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -11,7 +11,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "keywords": [

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -6,11 +6,13 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsc --build .",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts"
+    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "keywords": [
     "mds",

--- a/packages/mds-compliance/tsconfig.json
+++ b/packages/mds-compliance/tsconfig.json
@@ -4,16 +4,16 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../mds-agency" },
-    { "path": "../mds-api-server" },
-    { "path": "../mds-cache" },
-    { "path": "../mds-db" },
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-policy" },
-    { "path": "../mds-provider" },
-    { "path": "../mds-stream" },
-    { "path": "../mds-test-data" },
-    { "path": "../mds-utils" }
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-agency" },
+    { "path": "../../packages/mds-cache" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-policy" },
+    { "path": "../../packages/mds-provider" },
+    { "path": "../../packages/mds-stream" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-utils" }
   ]
 }

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -25,10 +25,12 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsc --build .",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts"
+    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -20,7 +20,9 @@
     "mds-utils": "0.1.0",
     "uuid": "3.3.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mds-test-data": "0.1.0"
+  },
   "main": "dist/api.js",
   "types": "dist/api.d.ts",
   "scripts": {

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -30,7 +30,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -30,7 +30,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-daily/tsconfig.json
+++ b/packages/mds-daily/tsconfig.json
@@ -4,12 +4,14 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../mds-api-server" },
-    { "path": "../mds-cache" },
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-providers" },
-    { "path": "../mds-test-data" },
-    { "path": "../mds-utils" }
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-cache" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-providers" },
+    { "path": "../../packages/mds-stream" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-utils" }
   ]
 }

--- a/packages/mds-db/package.json
+++ b/packages/mds-db/package.json
@@ -21,8 +21,9 @@
     "mds-enums": "0.1.0",
     "mds-logger": "0.1.0",
     "mds-utils": "0.1.0",
-    "mds-test-data": "0.1.0",
     "pg": "7.11.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "mds-test-data": "0.1.0"
+  }
 }

--- a/packages/mds-db/tsconfig.json
+++ b/packages/mds-db/tsconfig.json
@@ -4,9 +4,9 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-test-data" },
-    { "path": "../mds-utils" }
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-utils" }
   ]
 }

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -26,10 +26,12 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsc --build .",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
+    "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts"
+    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -31,7 +31,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -31,7 +31,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   }
 }

--- a/packages/mds-policy/tsconfig.json
+++ b/packages/mds-policy/tsconfig.json
@@ -4,11 +4,11 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../mds-api-server" },
-    { "path": "../mds-db" },
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-providers" },
-    { "path": "../mds-utils" }
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-providers" },
+    { "path": "../../packages/mds-utils" }
   ]
 }

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -15,7 +15,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "dependencies": {

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -29,10 +29,11 @@
     "mds-logger": "0.1.0",
     "mds-providers": "0.1.0",
     "mds-stream": "0.1.0",
-    "mds-test-data": "0.1.0",
     "mds-utils": "0.1.0",
     "url": "0.11.0",
     "uuid": "3.3.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "mds-test-data": "0.1.0"
+  }
 }

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -9,12 +9,14 @@
   "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsc --build .",
-    "start": "nodemon --watch '../../**/*.*' --ext 'ts js' --exec ts-node server.ts",
-    "stream": "ts-node stream",
+    "start": "yarn watch server",
+    "stream": "yarn watch stream",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts"
+    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
+    "watch": "nodemon --watch '../..' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch:exec": "yarn build && ts-node"
   },
   "dependencies": {
     "express": "4.17.1",

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -15,7 +15,7 @@
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --require source-map-support/register --recursive tests/**/*.ts",
-    "watch": "nodemon --watch '../../packages' --ignore '*.d.ts' --ext 'ts' --exec yarn watch:exec",
+    "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec",
     "watch:exec": "yarn build && ts-node"
   },
   "dependencies": {

--- a/packages/mds-provider/tsconfig.json
+++ b/packages/mds-provider/tsconfig.json
@@ -4,14 +4,14 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../mds-api-server" },
-    { "path": "../mds-cache" },
-    { "path": "../mds-db" },
-    { "path": "../mds-enums" },
-    { "path": "../mds-logger" },
-    { "path": "../mds-providers" },
-    { "path": "../mds-stream" },
-    { "path": "../mds-test-data" },
-    { "path": "../mds-utils" }
+    { "path": "../../packages/mds-api-server" },
+    { "path": "../../packages/mds-cache" },
+    { "path": "../../packages/mds-db" },
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-providers" },
+    { "path": "../../packages/mds-stream" },
+    { "path": "../../packages/mds-test-data" },
+    { "path": "../../packages/mds-utils" }
   ]
 }

--- a/packages/mds-stream/tsconfig.json
+++ b/packages/mds-stream/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../mds-logger" }]
+  "references": [{ "path": "../../packages/mds-logger" }]
 }

--- a/packages/mds-test-data/package.json
+++ b/packages/mds-test-data/package.json
@@ -12,8 +12,8 @@
   "author": "City of Los Angeles",
   "license": "Apache-2.0",
   "dependencies": {
-    "mds-enums": "0.1.0",
     "ladot-service-areas": "0.1.0",
+    "mds-enums": "0.1.0",
     "mds-logger": "0.1.0",
     "mds-utils": "0.1.0",
     "uuid4": "1.1.4"

--- a/packages/mds-test-data/tsconfig.json
+++ b/packages/mds-test-data/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [{ "path": "../mds-enums" }, { "path": "../mds-logger" }, { "path": "../mds-utils" }]
+  "references": [
+    { "path": "../../packages/mds-enums" },
+    { "path": "../../packages/mds-logger" },
+    { "path": "../../packages/mds-utils" }
+  ]
 }

--- a/packages/mds-utils/package.json
+++ b/packages/mds-utils/package.json
@@ -22,7 +22,5 @@
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.{js,ts}'",
     "test:unit": "exit 0"
   },
-  "devDependencies": {
-    "@types/point-in-polygon": "1.0.0"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
Now that `mds-core` is 100% TypeScript we can adjust the npm scripts `package.json` and project references `tsconfig.json` for improved watch mode and a better overall local development experience.