### PR TITLE
[mds-all] uniformly use VEHICLE_TYPES and PROPULSION_TYPES in tests

### DIFF
--- a/packages/mds-agency/tests/test.ts
+++ b/packages/mds-agency/tests/test.ts
@@ -21,11 +21,11 @@
 
 import supertest from 'supertest'
 import test from 'unit.js'
-import { VEHICLE_EVENTS, VEHICLE_STATUSES } from 'mds-enums'
-import { Timestamp, Device, VehicleEvent, Telemetry } from 'mds'
+import { VEHICLE_EVENTS, VEHICLE_STATUSES, VEHICLE_TYPES, PROPULSION_TYPES } from 'mds-enums'
+import { Timestamp, Device, VehicleEvent } from 'mds'
 import db from 'mds-db'
 import cache from 'mds-cache'
-import { makeDevices, makeEvents, makeEventsWithTelemetry, COMPLIANCE_AUTH } from 'mds-test-data'
+import { makeDevices, makeEvents } from 'mds-test-data'
 import { server } from 'mds-api-server'
 import { api } from '../api'
 
@@ -80,8 +80,8 @@ const TEST_VEHICLE = {
   device_id: DEVICE_UUID,
   provider_id: PROVIDER_UUID,
   vehicle_id: 'test-id-1',
-  type: 'bicycle', // FIXME constant
-  propulsion: ['human'], // FIXME constant
+  type: VEHICLE_TYPES.bicycle,
+  propulsion: [PROPULSION_TYPES.human],
   year: 2018,
   mfgr: 'Schwinn',
   model: 'Mantaray'
@@ -296,6 +296,7 @@ describe('Tests API', () => {
 
   it('verifies post device bad propulsion', done => {
     const badVehicle = deepCopy(TEST_VEHICLE)
+    // @ts-ignore: Spoofing garbage data
     badVehicle.propulsion = ['hamster']
     request
       .post('/vehicles')
@@ -373,6 +374,7 @@ describe('Tests API', () => {
   })
   it('verifies post device bad type', done => {
     const badVehicle = deepCopy(TEST_VEHICLE)
+    // @ts-ignore: Spoofing garbage data
     badVehicle.type = 'hamster'
     request
       .post('/vehicles')

--- a/packages/mds-audit/tests/api.spec.ts
+++ b/packages/mds-audit/tests/api.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import supertest from 'supertest'
-import { VEHICLE_EVENTS, AUDIT_EVENT_TYPES } from 'mds-enums'
+import { VEHICLE_EVENTS, AUDIT_EVENT_TYPES, PROPULSION_TYPES, VEHICLE_TYPES } from 'mds-enums'
 import { PROVIDER_UUID, PROVIDER_AUTH, makeEventsWithTelemetry, makeDevices, COMPLIANCE_AUTH } from 'mds-test-data'
 import { now } from 'mds-utils'
 import { Device, Timestamp, Telemetry } from 'mds'
@@ -72,8 +72,8 @@ describe('Testing API', () => {
       device_id: provider_device_id,
       provider_id,
       vehicle_id: provider_vehicle_id,
-      propulsion: ['electric'],
-      type: 'scooter',
+      propulsion: [PROPULSION_TYPES.electric],
+      type: VEHICLE_TYPES.scooter,
       recorded: timestamp
     }).then(() => {
       db.writeEvent({

--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -9,7 +9,7 @@ import db from 'mds-db'
 import supertest from 'supertest'
 import { now } from 'mds-utils'
 import { Telemetry, Device, Policy, Geography, VehicleEvent, UUID } from 'mds'
-import { RULE_TYPES } from 'mds-enums'
+import { RULE_TYPES, VEHICLE_TYPES, PROPULSION_TYPES } from 'mds-enums'
 import MockDate from 'mockdate'
 import { Feature, Polygon } from 'geojson'
 import uuidv4 from 'uuid/v4'
@@ -58,8 +58,8 @@ const TEST_VEHICLE = {
   device_id: DEVICE_UUID,
   provider_id: PROVIDER_UUID,
   vehicle_id: 'test-id-1',
-  type: 'bicycle', // FIXME constant
-  propulsion: ['human'], // FIXME constant
+  type: VEHICLE_TYPES.bicycle,
+  propulsion: [PROPULSION_TYPES.human],
   year: 2018,
   mfgr: 'Schwinn',
   model: 'Mantaray'
@@ -85,7 +85,7 @@ const COUNT_POLICY_JSON: Policy = {
       rule_type: RULE_TYPES.count,
       geographies: [GEOGRAPHY_UUID],
       statuses: { available: [], unavailable: [], reserved: [], trip: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 10,
       minimum: 5
     }
@@ -127,7 +127,7 @@ const COUNT_POLICY_JSON_3: Policy = {
       rule_type: RULE_TYPES.count,
       geographies: [GEOGRAPHY_UUID],
       statuses: { available: ['service_start'], unavailable: [], reserved: [], trip: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 10
     }
   ]
@@ -150,7 +150,7 @@ const TIME_POLICY_JSON: Policy = {
       rule_units: 'minutes',
       geographies: [GEOGRAPHY_UUID],
       statuses: { available: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 7200
     }
   ]
@@ -864,7 +864,7 @@ describe('Tests Compliance API:', () => {
             rule_type: RULE_TYPES.count,
             geographies: veniceSpecOpsPointIds,
             statuses: { available: ['provider_drop_off'] },
-            vehicle_types: ['bicycle', 'scooter'],
+            vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
             maximum: 0
           },
           {
@@ -873,7 +873,7 @@ describe('Tests Compliance API:', () => {
             rule_type: RULE_TYPES.count,
             geographies: ['e0e4a085-7a50-43e0-afa4-6792ca897c5a'],
             statuses: { available: ['provider_drop_off'] },
-            vehicle_types: ['bicycle', 'scooter'],
+            vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
             maximum: 0
           }
         ]

--- a/packages/mds-daily/tests/test.ts
+++ b/packages/mds-daily/tests/test.ts
@@ -21,7 +21,7 @@
 
 import supertest from 'supertest'
 import test from 'unit.js'
-import { VEHICLE_EVENTS } from 'mds-enums'
+import { VEHICLE_EVENTS, VEHICLE_TYPES, PROPULSION_TYPES } from 'mds-enums'
 import { Timestamp, Device, VehicleEvent, Telemetry } from 'mds'
 import db from 'mds-db'
 import cache from 'mds-cache'
@@ -79,8 +79,8 @@ const TEST_VEHICLE = {
   device_id: DEVICE_UUID,
   provider_id: PROVIDER_UUID,
   vehicle_id: 'test-id-1',
-  type: 'bicycle', // FIXME constant
-  propulsion: ['human'], // FIXME constant
+  type: VEHICLE_TYPES.bicycle,
+  propulsion: [PROPULSION_TYPES.human],
   year: 2018,
   mfgr: 'Schwinn',
   model: 'Mantaray'

--- a/packages/mds-policy/tests/api.spec.ts
+++ b/packages/mds-policy/tests/api.spec.ts
@@ -21,6 +21,7 @@
 
 import supertest from 'supertest'
 import test from 'unit.js'
+import { VEHICLE_TYPES } from 'mds-enums'
 import { now, days } from 'mds-utils'
 import { Policy } from 'mds'
 import { server } from 'mds-api-server'
@@ -62,7 +63,7 @@ const policy_json: Policy = {
       name: 'Greater LA',
       geographies: [GEOGRAPHY_UUID],
       statuses: { available: [], unavailable: [], reserved: [], trip: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 3000,
       minimum: 500
     }
@@ -89,7 +90,7 @@ const policy2_json: Policy = {
       rule_units: 'minutes',
       geographies: [GEOGRAPHY_UUID],
       statuses: { available: [], reserved: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 7200
     },
     {
@@ -99,7 +100,7 @@ const policy2_json: Policy = {
       rule_units: 'minutes',
       geographies: [GEOGRAPHY_UUID],
       statuses: { unavailable: [], trip: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 720
     }
   ]
@@ -124,7 +125,7 @@ const policy3_json: Policy = {
       rule_units: 'mph',
       geographies: [GEOGRAPHY_UUID],
       statuses: { trip: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       maximum: 15
     },
     {
@@ -134,7 +135,7 @@ const policy3_json: Policy = {
       rule_type: 'speed',
       rule_units: 'mph',
       statuses: { trip: [] },
-      vehicle_types: ['bicycle', 'scooter'],
+      vehicle_types: [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter],
       days: ['sat', 'sun'],
       start_time: '12:00',
       end_time: '23:59',

--- a/packages/mds-provider/tests/test.ts
+++ b/packages/mds-provider/tests/test.ts
@@ -16,6 +16,7 @@
 
 import supertest from 'supertest'
 import { now } from 'mds-utils'
+import { VEHICLE_TYPES, PROPULSION_TYPES } from 'mds-enums'
 import { PROVIDER_UUID, PROVIDER_AUTH, makeTelemetryStream, makeTelemetry, makeDevices } from 'mds-test-data'
 import test from 'unit.js'
 import { Device, Telemetry, VehicleEvent } from 'mds'
@@ -44,8 +45,8 @@ const TEST_DEVICE: Device = {
   device_id: DEVICE_UUID,
   provider_id: PROVIDER_UUID,
   vehicle_id: DEVICE_VIN,
-  type: 'bicycle', // FIXME constant
-  propulsion: ['human'], // FIXME constant
+  type: VEHICLE_TYPES.bicycle,
+  propulsion: [PROPULSION_TYPES.human],
   year: 2018,
   mfgr: 'Schwinn',
   model: 'Mantaray',
@@ -56,8 +57,8 @@ const TEST_DEVICE2: Device = {
   device_id: DEVICE_UUID2,
   provider_id: PROVIDER_UUID,
   vehicle_id: DEVICE_VIN2,
-  type: 'scooter', // FIXME constant
-  propulsion: ['electric'], // FIXME constant
+  type: VEHICLE_TYPES.scooter,
+  propulsion: [PROPULSION_TYPES.electric],
   year: 2017,
   mfgr: 'Xiaomi',
   model: 'Mi',
@@ -332,7 +333,7 @@ describe('Tests app', () => {
           .object(status_change)
           .hasProperty('provider_id', PROVIDER_UUID)
           .hasProperty('vehicle_id', DEVICE_VIN)
-          .hasProperty('vehicle_type', 'bicycle')
+          .hasProperty('vehicle_type', VEHICLE_TYPES.bicycle)
           .hasProperty('event_type', 'reserved')
           .hasProperty('event_type_reason', 'user_pick_up')
         done(err)

--- a/packages/mds-test-data/index.ts
+++ b/packages/mds-test-data/index.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  */
 
-import { VEHICLE_EVENTS, PROPULSION_TYPE, VEHICLE_EVENT } from 'mds-enums'
+import { VEHICLE_EVENTS, PROPULSION_TYPE, VEHICLE_EVENT, VEHICLE_TYPES, PROPULSION_TYPES } from 'mds-enums'
 import { UUID, Device, Timestamp, Telemetry, VehicleEvent } from 'mds'
 import { Geometry } from 'geojson'
 import { StatusChange, Trip } from 'mds-db/types'
@@ -46,8 +46,8 @@ const JUMP_TEST_DEVICE_1: Device = {
   provider_id: JUMP_UUID,
   device_id: 'e9edbe74-f7be-48e0-a63a-92f4bc1af5ed',
   vehicle_id: '1230987',
-  type: 'scooter',
-  propulsion: ['electric'],
+  type: VEHICLE_TYPES.scooter,
+  propulsion: [PROPULSION_TYPES.electric],
   year: 2018,
   mfgr: 'Schwinn',
   model: 'whoknows',
@@ -134,31 +134,31 @@ function makeDevices(count: number, timestamp: Timestamp, provider_id = TEST_UUI
     switch (provider_id) {
       case LIME_UUID:
       case JUMP_UUID:
-        type = ['bicycle', 'scooter'][coin]
-        if (type === 'bicycle') {
-          propulsion = [['human', 'electric'], ['human']][coin] as PROPULSION_TYPE[]
+        type = [VEHICLE_TYPES.bicycle, VEHICLE_TYPES.scooter][coin]
+        if (type === VEHICLE_TYPES.bicycle) {
+          propulsion = [[PROPULSION_TYPES.human, PROPULSION_TYPES.electric], [PROPULSION_TYPES.human]][coin] as PROPULSION_TYPE[]
         } else {
-          propulsion = ['electric']
+          propulsion = [PROPULSION_TYPES.electric]
         }
         break
       case BIRD_UUID:
-        type = 'scooter'
-        propulsion = ['electric']
+        type = VEHICLE_TYPES.scooter
+        propulsion = [PROPULSION_TYPES.electric]
         break
       default:
-        type = 'bicycle'
-        propulsion = ['human']
+        type = VEHICLE_TYPES.bicycle
+        propulsion = [PROPULSION_TYPES.human]
         break
     }
     let mfgr
     let model
     const year = rangeRandomInt(2016, 2020)
     switch (type) {
-      case 'scooter':
+      case VEHICLE_TYPES.scooter:
         mfgr = 'Xiaomi'
         model = 'M365'
         break
-      case 'bicycle':
+      case VEHICLE_TYPES.bicycle:
         mfgr = 'Schwinn'
         model = 'Mantaray'
         break


### PR DESCRIPTION
Found a bunch of places where we had legacy strings.  Replaced.  No new tests.

## PR Checklist

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [x] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [x] Provider
- [x] Agency
- [x] Audit
- [x] Policy
- [x] Compliance

