### PR TITLE
[mds-provider] remove sequence column

### DIFF
--- a/packages/mds-db/index.ts
+++ b/packages/mds-db/index.ts
@@ -1293,7 +1293,7 @@ async function readStatusChanges(
   }
 
   const { rows: status_changes } = await exec(
-    `SELECT * FROM ${schema.STATUS_CHANGES_TABLE} ${where} ORDER BY recorded ASC, device_id ASC, event_time ASC${
+    `SELECT * FROM ${schema.STATUS_CHANGES_TABLE} ${where} ORDER BY recorded ASC, event_time ASC, device_id ASC${
       skip ? ` OFFSET ${vals.add(skip)}` : ''
     }${take ? ` LIMIT ${vals.add(take)}` : ''}`,
     vals.values()

--- a/packages/mds-db/index.ts
+++ b/packages/mds-db/index.ts
@@ -10,7 +10,6 @@ import {
   Telemetry,
   Recorded,
   DeviceID,
-  VehicleEventPrimaryKey,
   Rule
 } from 'mds'
 import {
@@ -1473,8 +1472,8 @@ async function readRule(rule_id: UUID): Promise<Rule> {
 }
 
 async function readUnprocessedStatusChangeEvents(
-  before: VehicleEventPrimaryKey,
-  take: number
+  before: { timestamp: Timestamp; device_id: UUID } | null,
+  take: number = 1000
 ): Promise<{ count: number; events: Recorded<VehicleEvent>[] }> {
   const client = await getReadOnlyClient()
   const vals = new SqlVals()

--- a/packages/mds-db/migration.ts
+++ b/packages/mds-db/migration.ts
@@ -120,7 +120,7 @@ async function removeAuditVehicleIdColumnFromAuditsTable(client: MDSPostgresClie
   const AUDIT_VEHICLE_ID_COL = 'audit_vehicle_id'
   const AUDIT_DEVICE_ID_COL = 'audit_device_id'
   // Only run if the audit_vehicle_id column has been removed from the schema
-  if (!schema.AUDITS_COLS.some(column => column === AUDIT_VEHICLE_ID_COL)) {
+  if (!schema.AUDITS_COLS.some(column => (column as string) === AUDIT_VEHICLE_ID_COL)) {
     const exec = SqlExecuter(client)
     // Make sure this migration hasn't already run
     const result = await exec(
@@ -143,15 +143,15 @@ async function removeAuditVehicleIdColumnFromAuditsTable(client: MDSPostgresClie
 }
 
 async function recreateProviderTables(client: MDSPostgresClient) {
-  const SEQUENCE_COL = 'sequence'
+  const PROVIDER_TRIP_ID = 'provider_trip_id'
   const RECREATE_TABLES = csv([schema.TRIPS_TABLE, schema.STATUS_CHANGES_TABLE])
 
   // Make sure this migration is still required
-  if (schema.TRIPS_COLS.some(column => column === SEQUENCE_COL)) {
+  if (schema.TRIPS_COLS.some(column => (column as string) === PROVIDER_TRIP_ID)) {
     const exec = SqlExecuter(client)
     // Make sure this migration hasn't already run
     const result = await exec(
-      `SELECT column_name FROM information_schema.columns WHERE table_name = '${schema.TRIPS_TABLE}' AND column_name = '${SEQUENCE_COL}' AND table_catalog = CURRENT_CATALOG AND table_schema= CURRENT_SCHEMA`
+      `SELECT column_name FROM information_schema.columns WHERE table_name = '${schema.TRIPS_TABLE}' AND column_name = '${PROVIDER_TRIP_ID}' AND table_catalog = CURRENT_CATALOG AND table_schema= CURRENT_SCHEMA`
     )
     if (result.rowCount === 0) {
       // Do the migration

--- a/packages/mds-db/schema.ts
+++ b/packages/mds-db/schema.ts
@@ -67,8 +67,7 @@ const TRIPS_COLS = [
   'parking_verification_url',
   'standard_cost',
   'actual_cost',
-  'recorded',
-  'sequence'
+  'recorded'
 ] as const
 
 const STATUS_CHANGES_COLS = [
@@ -84,8 +83,7 @@ const STATUS_CHANGES_COLS = [
   'event_location',
   'battery_pct',
   'associated_trip',
-  'recorded',
-  'sequence'
+  'recorded'
 ] as const
 
 // audit
@@ -182,7 +180,6 @@ const PG_TYPES: { [propName: string]: string } = {
   parking_verification_url: 'varchar(255)',
   standard_cost: 'int',
   actual_cost: 'int',
-  sequence: 'bigint',
 
   event_time: 'bigint NOT NULL',
   event_location: 'jsonb',

--- a/packages/mds-db/types.ts
+++ b/packages/mds-db/types.ts
@@ -28,7 +28,6 @@ export interface Trip {
   standard_cost?: number | null
   actual_cost?: number | null
   recorded: Timestamp
-  sequence?: number | null
 }
 
 // TODO move to mds-db?
@@ -57,7 +56,6 @@ export interface StatusChange {
   battery_pct: number | null
   associated_trip: UUID | null
   recorded: Timestamp
-  sequence?: number | null
 }
 
 export type StatusChangeEvent = Pick<StatusChange, 'event_type' | 'event_type_reason'>

--- a/packages/mds-provider/api.ts
+++ b/packages/mds-provider/api.ts
@@ -22,8 +22,8 @@ import cache from 'mds-cache'
 import { providerName } from 'mds-providers' // map of uuids -> obj
 
 import { makeTelemetry, makeEvents, makeDevices } from 'mds-test-data'
-import { isUUID, now, pathsFor, isTimestamp, round, routeDistance } from 'mds-utils'
-import { Timestamp, Telemetry } from 'mds'
+import { isUUID, now, pathsFor, round, routeDistance } from 'mds-utils'
+import { Telemetry } from 'mds'
 import { ReadTripsResult, Trip, ReadStatusChangesResult, StatusChange } from 'mds-db/types'
 import { asJsonApiLinks, asPagingParams } from 'mds-api-helpers'
 import { Feature, FeatureCollection } from 'geojson'
@@ -186,25 +186,6 @@ function api(app: express.Express): express.Express {
 
   // / /////////////////////// trips /////////////////////////////////
 
-  const getStage0Properties = (items: { recorded: Timestamp; sequence?: number | null }[]) => {
-    if (items && items.length > 0) {
-      const { recorded, sequence } = items[items.length - 1]
-      return { last_sequence: `${recorded}-${(sequence || 0).toString().padStart(4, '0')}` }
-    }
-    return {}
-  }
-
-  const asSequence = (value: unknown): [number, number] | undefined | Error => {
-    if (typeof value === 'string' && value.length > 0) {
-      const [recorded, sequence, ...extra] = value.split('-').map(Number)
-      if (extra.length === 0 && isTimestamp(recorded) && Number.isInteger(sequence)) {
-        return [recorded, sequence]
-      }
-      return Error(`Invalid sequence: ${value}`)
-    }
-    return undefined
-  }
-
   /**
    * Convert a Telemetry object into a GeoJSON Feature
    * @param item a Telemetry object
@@ -237,11 +218,10 @@ function api(app: express.Express): express.Express {
 
   const asTrip = async ({
     recorded,
-    sequence,
     first_trip_enter,
     last_trip_leave,
     ...trip
-  }: Trip): Promise<Omit<Trip, 'recorded' | 'sequence'>> => {
+  }: Trip): Promise<Omit<Trip, 'recorded'>> => {
     const { trip_start, trip_end } = trip
     if (trip_start && trip_end && trip_end > trip_start) {
       const telemetry = await db.readTelemetry(trip.device_id, trip_start, trip_end)
@@ -263,12 +243,6 @@ function api(app: express.Express): express.Express {
 
     // Extensions to override paging
     const { skip, take } = asPagingParams(req.query)
-    const last_sequence = asSequence(req.query.last_sequence)
-
-    if (last_sequence instanceof Error) {
-      res.status(400).send({ error: last_sequence.message })
-      return
-    }
 
     if (provider_id && !isUUID(provider_id)) {
       return res.status(400).send({
@@ -290,8 +264,7 @@ function api(app: express.Express): express.Express {
         min_end_time,
         max_end_time,
         skip,
-        take,
-        last_sequence
+        take
       })
 
       res.status(200).send({
@@ -299,8 +272,7 @@ function api(app: express.Express): express.Express {
         data: {
           trips: await Promise.all(trips.map(asTrip))
         },
-        links: asJsonApiLinks(req, skip, take, count),
-        ...getStage0Properties(trips)
+        links: asJsonApiLinks(req, skip, take, count)
       })
     } catch (err) {
       // 500 Internal Server Error
@@ -313,11 +285,7 @@ function api(app: express.Express): express.Express {
 
   // / ////////////////////////////// status_changes /////////////////////////////
 
-  const asStatusChange = ({
-    recorded,
-    sequence,
-    ...props
-  }: StatusChange): Omit<StatusChange, 'recorded' | 'sequence'> => props
+  const asStatusChange = ({ recorded, ...props }: StatusChange): Omit<StatusChange, 'recorded'> => props
 
   app.get(pathsFor('/status_changes'), async (req: ProviderApiRequest, res: ProviderApiResponse) => {
     // Standard Provider parameters
@@ -327,12 +295,6 @@ function api(app: express.Express): express.Express {
 
     // Extensions to override paging
     const { skip, take } = asPagingParams(req.query)
-    const last_sequence = asSequence(req.query.last_sequence)
-
-    if (last_sequence instanceof Error) {
-      res.status(400).send({ error: last_sequence.message })
-      return
-    }
 
     if (provider_id && !isUUID(provider_id)) {
       return res.status(400).send({
@@ -351,8 +313,7 @@ function api(app: express.Express): express.Express {
         start_time,
         end_time,
         skip,
-        take,
-        last_sequence
+        take
       })
 
       res.status(200).send({
@@ -360,8 +321,7 @@ function api(app: express.Express): express.Express {
         data: {
           status_changes: status_changes.map(asStatusChange)
         },
-        links: asJsonApiLinks(req, skip, take, count),
-        ...getStage0Properties(status_changes)
+        links: asJsonApiLinks(req, skip, take, count)
       })
     } catch (err) {
       // 500 Internal Server Error

--- a/packages/mds-provider/event-processor/index.ts
+++ b/packages/mds-provider/event-processor/index.ts
@@ -119,7 +119,6 @@ const processor = async (options: ReadStreamOptions): Promise<number> => {
       ])
       return entries.length
     }
-    logger.info('No entries to process.')
   } else {
     logger.info('Stream Unavailable')
   }

--- a/packages/mds-provider/event-processor/index.ts
+++ b/packages/mds-provider/event-processor/index.ts
@@ -72,7 +72,7 @@ const processor = async (options: ReadStreamOptions): Promise<number> => {
   const info = await stream.getStreamInfo('provider:event')
 
   if (info) {
-    const events = await db.readEventsRangeExclusive(
+    const { count, events } = await db.readEventsRangeExclusive(
       statusChangePrimaryKey(await db.getMostRecentStatusChange()),
       streamItemPrimaryKey(info.firstEntry),
       options.count || 1000
@@ -93,7 +93,9 @@ const processor = async (options: ReadStreamOptions): Promise<number> => {
         : await readStreamEntries(options)
 
     if (entries.length > 0) {
-      logger.info(`Processing ${entries.length} entries from ${name}`)
+      logger.info(
+        `Processing ${entries.length} entries from ${name} ${count > 0 ? `backlog (${count} events)` : 'stream'}`
+      )
 
       // Run stream labelers
       const [providers, devices, trips] = await Promise.all([

--- a/packages/mds-provider/event-processor/index.ts
+++ b/packages/mds-provider/event-processor/index.ts
@@ -20,7 +20,6 @@ import stream, { ReadStreamOptions, StreamItem } from 'mds-stream'
 import uuid from 'uuid'
 import { isUUID } from 'mds-utils'
 import { VehicleEvent, VehicleEventPrimaryKey } from 'mds'
-import { StatusChange } from 'mds-db/dist/types'
 import { DeviceLabeler } from './labelers/device-labeler'
 import { ProviderLabeler } from './labelers/provider-labeler'
 import { StreamEntry } from './types'
@@ -60,20 +59,11 @@ const streamItemPrimaryKey = (item: StreamItem | null): VehicleEventPrimaryKey =
   return null
 }
 
-const statusChangePrimaryKey = (item: StatusChange | null): VehicleEventPrimaryKey => {
-  if (item) {
-    const { event_time: timestamp, device_id } = item
-    return { timestamp, device_id }
-  }
-  return null
-}
-
 const processor = async (options: ReadStreamOptions): Promise<number> => {
   const info = await stream.getStreamInfo('provider:event')
 
   if (info) {
-    const { count, events } = await db.readEventsRangeExclusive(
-      statusChangePrimaryKey(await db.getMostRecentStatusChange()),
+    const { count, events } = await db.readUnprocessedStatusChangeEvents(
       streamItemPrimaryKey(info.firstEntry),
       options.count || 1000
     )

--- a/packages/mds-provider/event-processor/index.ts
+++ b/packages/mds-provider/event-processor/index.ts
@@ -19,7 +19,7 @@ import logger from 'mds-logger'
 import stream, { ReadStreamOptions, StreamItem } from 'mds-stream'
 import uuid from 'uuid'
 import { isUUID } from 'mds-utils'
-import { VehicleEvent, VehicleEventPrimaryKey } from 'mds'
+import { VehicleEvent, Timestamp, UUID } from 'mds'
 import { DeviceLabeler } from './labelers/device-labeler'
 import { ProviderLabeler } from './labelers/provider-labeler'
 import { StreamEntry } from './types'
@@ -49,7 +49,7 @@ const readStreamEntries = async (options: ReadStreamOptions) => {
   }
 }
 
-const streamItemPrimaryKey = (item: StreamItem | null): VehicleEventPrimaryKey => {
+const streamItemVehicleEventKey = (item: StreamItem | null): { timestamp: Timestamp; device_id: UUID } | null => {
   if (item) {
     const {
       data: { timestamp, device_id }
@@ -64,8 +64,8 @@ const processor = async (options: ReadStreamOptions): Promise<number> => {
 
   if (info) {
     const { count, events } = await db.readUnprocessedStatusChangeEvents(
-      streamItemPrimaryKey(info.firstEntry),
-      options.count || 1000
+      streamItemVehicleEventKey(info.firstEntry),
+      options.count
     )
 
     const { name, entries }: { name: string; entries: StreamEntry[] } =

--- a/packages/mds-provider/event-processor/labelers/device-labeler.ts
+++ b/packages/mds-provider/event-processor/labelers/device-labeler.ts
@@ -60,7 +60,11 @@ export const DeviceLabeler = async (entries: StreamEntry[]): Promise<StreamEntry
       { labels: {}, labeled: 0 }
     )
 
-    logger.info(`|- Device Labeler: Labeled ${labeled} ${labeled === 1 ? 'entry' : 'entries'}`)
+    logger.info(
+      `|- Device Labeler: Labeled ${labeled} ${labeled === 1 ? 'entry' : 'entries'} (${device_ids.length} ${
+        device_ids.length === 1 ? 'device' : 'devices'
+      })`
+    )
 
     return labels
   }

--- a/packages/mds-provider/event-processor/labelers/provider-labeler.ts
+++ b/packages/mds-provider/event-processor/labelers/provider-labeler.ts
@@ -45,7 +45,7 @@ export const ProviderLabeler = async (entries: StreamEntry[]): Promise<StreamEnt
       {}
     )
 
-    // Create the device labels
+    // Create the provider labels
     const { labels, labeled } = provider_entries.reduce(
       (result, entry) => {
         const provider = provider_map[entry.data.provider_id]
@@ -57,7 +57,11 @@ export const ProviderLabeler = async (entries: StreamEntry[]): Promise<StreamEnt
       { labels: {}, labeled: 0 }
     )
 
-    logger.info(`|- Provider Labeler: Labeled ${labeled} ${labeled === 1 ? 'entry' : 'entries'}`)
+    logger.info(
+      `|- Provider Labeler: Labeled ${labeled} ${labeled === 1 ? 'entry' : 'entries'} (${provider_ids.length} ${
+        provider_ids.length === 1 ? 'provider' : 'providers'
+      })`
+    )
 
     return labels
   }

--- a/packages/mds-provider/event-processor/labelers/trip-labeler.ts
+++ b/packages/mds-provider/event-processor/labelers/trip-labeler.ts
@@ -49,7 +49,7 @@ export const TripLabeler = async (entries: StreamEntry[]): Promise<StreamEntryLa
       {}
     )
 
-    // Create the device labels
+    // Create the trip labels
     const { labels, labeled } = trip_entries.reduce(
       (result, entry) => {
         const trip = trip_map[entry.data.trip_id]
@@ -61,7 +61,11 @@ export const TripLabeler = async (entries: StreamEntry[]): Promise<StreamEntryLa
       { labels: {}, labeled: 0 }
     )
 
-    logger.info(`|- Trip Labeler: Labeled ${labeled} ${labeled === 1 ? 'entry' : 'entries'}`)
+    logger.info(
+      `|- Trip Labeler: Labeled ${labeled} ${labeled === 1 ? 'entry' : 'entries'} (${trip_ids.length} ${
+        trip_ids.length === 1 ? 'trip' : 'trips'
+      })`
+    )
 
     return labels
   }

--- a/types/mds.d.ts
+++ b/types/mds.d.ts
@@ -36,8 +36,6 @@ export interface Device {
 
 export type DeviceID = Pick<Device, 'provider_id' | 'device_id'>
 
-export type VehicleEventPrimaryKey = { timestamp: Timestamp; device_id: UUID } | null
-
 // Represents a row in the "events" table
 // Named "VehicleEvent" to avoid confusion with the DOM's Event interface
 export interface VehicleEvent {


### PR DESCRIPTION
By guaranteeing query order (recorded IDX + PK), we can use the existing `skip/take` parameters to reliably poll for new status changes without the need for an additional sequencing mechanism.

## Impacts
- [x] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance

