### PR TITLE
[mds-api-server] Remove redundancy using standard authorizer claims

### DIFF
--- a/aws-lambda/aws-serverless-express-handler/index.ts
+++ b/aws-lambda/aws-serverless-express-handler/index.ts
@@ -41,7 +41,7 @@ export const ApiGatewayAuthorizer: ApiAuthorizer = (req: ApiGatewayRequest) =>
     req.apiGateway.event &&
     req.apiGateway.event.requestContext &&
     req.apiGateway.event.requestContext.authorizer) ||
-  {}
+  null
 
 /* istanbul ignore next */
 export const AwsServerlessExpressHandler = (

--- a/aws-lambda/aws-serverless-express-handler/tests/index.spec.ts
+++ b/aws-lambda/aws-serverless-express-handler/tests/index.spec.ts
@@ -4,19 +4,19 @@ import { ApiGatewayRequest, ApiGatewayAuthorizer } from '../index'
 describe('Test API Gateway Authorizer', () => {
   it('No Authorizaton', done => {
     const authorizer = ApiGatewayAuthorizer({} as ApiGatewayRequest)
-    test.value(authorizer).is({})
+    test.value(authorizer).is(null)
     done()
   })
 
   it('No Event', done => {
     const authorizer = ApiGatewayAuthorizer({ apiGateway: {} } as ApiGatewayRequest)
-    test.value(authorizer).is({})
+    test.value(authorizer).is(null)
     done()
   })
 
   it('No Request Context', done => {
     const authorizer = ApiGatewayAuthorizer({ apiGateway: { event: {} } } as ApiGatewayRequest)
-    test.value(authorizer).is({})
+    test.value(authorizer).is(null)
     done()
   })
 
@@ -24,7 +24,7 @@ describe('Test API Gateway Authorizer', () => {
     const authorizer = ApiGatewayAuthorizer({
       apiGateway: { event: { requestContext: {} } }
     } as ApiGatewayRequest)
-    test.value(authorizer).is({})
+    test.value(authorizer).is(null)
     done()
   })
 

--- a/aws-lambda/mds-daily/server.ts
+++ b/aws-lambda/mds-daily/server.ts
@@ -19,7 +19,7 @@ import { server } from 'mds-api-server'
 import { api } from 'mds-daily'
 
 const {
-  env: { npm_package_name, PORT = 4001 }
+  env: { npm_package_name, PORT = 4005 }
 } = process
 
 /* eslint-reason avoids import of logger */

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -7,8 +7,6 @@
   "licence": "Apache-2.0",
   "dependencies": {
     "express": "4.17.1",
-    "jsonwebtoken": "8.5.1",
-    "jwt-decode": "2.2.0",
     "ladot-service-areas": "0.1.0",
     "mds-api-helpers": "0.1.0",
     "mds-api-server": "0.1.0",

--- a/packages/mds-agency/types.ts
+++ b/packages/mds-agency/types.ts
@@ -1,20 +1,13 @@
-import express from 'express'
 import { UUID } from 'mds'
 import { MultiPolygon } from 'geojson'
+import { ApiRequest, ApiResponse } from 'mds-api-server'
+import { ApiAuthorizerClaims } from 'mds-api-authorizer'
 
-// TODO this is same as ProviderApiRequest
-export interface AgencyApiRequest extends express.Request {
-  apiGateway?: {
-    event?: {
-      requestContext?: {
-        authorizer?: Partial<{
-          principalId: string
-          provider_id: UUID
-          scope: string
-          email: string
-        }>
-      }
-    }
+export type AgencyApiRequest = ApiRequest
+export interface AgencyApiResponse extends ApiResponse {
+  locals: {
+    claims: ApiAuthorizerClaims
+    provider_id: UUID
   }
 }
 

--- a/packages/mds-api-authorizer/index.ts
+++ b/packages/mds-api-authorizer/index.ts
@@ -2,36 +2,36 @@ import express from 'express'
 import jwtDecode from 'jwt-decode'
 import { UUID } from 'mds'
 
-export type ApiAuthorizerClaims = Partial<{
+export interface ApiAuthorizerClaims {
   principalId: string
   provider_id: UUID
   scope: string
-  email: string
-}>
+  email: string | null
+}
 
 const { TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id' } = process.env
 
-export type ApiAuthorizer = (req: express.Request) => ApiAuthorizerClaims
+export type ApiAuthorizer = (req: express.Request) => ApiAuthorizerClaims | null
 
 export const AuthorizationHeaderApiAuthorizer: ApiAuthorizer = req => {
   if (req.headers && req.headers.authorization) {
-    const decode = ([scheme, token]: string[]): ApiAuthorizerClaims => {
+    const decode = ([scheme, token]: string[]): ApiAuthorizerClaims | null => {
       const decoders: { [scheme: string]: () => ApiAuthorizerClaims } = {
         bearer: () => {
-          const { sub: principalId, [TOKEN_PROVIDER_ID_CLAIM]: provider_id, ...claims } = jwtDecode(token)
-          return { principalId, provider_id, ...claims }
+          const { sub: principalId, [TOKEN_PROVIDER_ID_CLAIM]: provider_id, scope, email, ...claims } = jwtDecode(token)
+          return { principalId, provider_id, scope, email, ...claims }
         },
         basic: () => {
           const [principalId, scope] = Buffer.from(token, 'base64')
             .toString()
             .split('|')
-          return { principalId, provider_id: principalId, scope }
+          return { principalId, provider_id: principalId, scope, email: null }
         }
       }
       const decoder = decoders[scheme.toLowerCase()]
-      return decoder ? decoder() : {}
+      return decoder ? decoder() : null
     }
     return decode(req.headers.authorization.split(' '))
   }
-  return {}
+  return null
 }

--- a/packages/mds-api-authorizer/tests/index.spec.ts
+++ b/packages/mds-api-authorizer/tests/index.spec.ts
@@ -9,13 +9,13 @@ const ADMIN_AUTH = `basic ${Buffer.from(`${PROVIDER_UUID}|${PROVIDER_SCOPES}`).t
 describe('Test API Authorizer', () => {
   it('No Authorizaton', done => {
     const authorizer = AuthorizationHeaderApiAuthorizer({} as express.Request)
-    test.value(authorizer).is({})
+    test.value(authorizer).is(null)
     done()
   })
 
   it('Invalid Authorizaton Scheme', done => {
     const authorizer = AuthorizationHeaderApiAuthorizer({ headers: { authorization: 'invalid' } } as express.Request)
-    test.value(authorizer).is({})
+    test.value(authorizer).is(null)
     done()
   })
 

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -7,7 +7,7 @@ export type ApiRequest = express.Request
 
 export interface ApiResponse extends express.Response {
   locals: {
-    claims: ApiAuthorizerClaims
+    claims: ApiAuthorizerClaims | null
   }
 }
 

--- a/packages/mds-audit/tests/api.spec.ts
+++ b/packages/mds-audit/tests/api.spec.ts
@@ -23,8 +23,8 @@ import cache from 'mds-cache'
 import test from 'unit.js'
 import uuid from 'uuid'
 import { server } from 'mds-api-server'
-import { api } from 'mds-audit/src/api'
 import db from 'mds-db'
+import { api } from '../src/api'
 
 process.env.PATH_PREFIX = '/audit'
 
@@ -96,8 +96,7 @@ describe('Testing API', () => {
 
   it('verifies get root', done => {
     request
-      .get('/audit')
-      .set('Authorization', PROVIDER_AUTH)
+      .get('/')
       .expect(200)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)
@@ -108,7 +107,6 @@ describe('Testing API', () => {
   it('verifies get /health without jwt', done => {
     request
       .get('/audit/health')
-      // .set('Authorization', PROVIDER_AUTH)
       .expect(200)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)

--- a/packages/mds-audit/tests/validators.spec.ts
+++ b/packages/mds-audit/tests/validators.spec.ts
@@ -31,7 +31,7 @@ import {
   isValidAuditEventType,
   isValidAuditIssueCode,
   isValidAuditNote
-} from 'mds-audit/src/validators'
+} from '../src/validators'
 
 describe('Tests validators', () => {
   it('verifies Audit Trip ID validator', done => {

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -209,7 +209,7 @@ function api(app: express.Express): express.Express {
   })
 
   app.get(pathsFor('/count/:rule_id'), async (req: ComplianceApiRequest, res: ComplianceApiResponse) => {
-    if (!(res.locals.provider_id && [TEST1_PROVIDER_ID, TEST2_PROVIDER_ID].includes(res.locals.provider_id))) {
+    if (![TEST1_PROVIDER_ID, TEST2_PROVIDER_ID].includes(res.locals.provider_id)) {
       res.status(401).send({ result: 'unauthorized access' })
     }
 

--- a/packages/mds-compliance/api.ts
+++ b/packages/mds-compliance/api.ts
@@ -18,93 +18,63 @@ import express from 'express'
 import cache from 'mds-cache'
 import stream from 'mds-stream'
 import db from 'mds-db'
-import jwtDecode from 'jwt-decode'
 import log from 'mds-logger'
 import { isUUID, now, days, pathsFor, head, getPolygon, pointInShape, isInStatesOrEvents } from 'mds-utils'
 import { Policy, Geography, VehicleEvent, ComplianceResponse, Device, UUID } from 'mds'
-import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID } from 'mds-providers'
+import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID, providerName } from 'mds-providers'
 import { Geometry, FeatureCollection } from 'geojson'
 import * as compliance_engine from './mds-compliance-engine'
-import { ComplianceApiRequest } from './types'
-
-function getAuth(req: ComplianceApiRequest): Partial<{ provider_id: string; scope: string }> {
-  // Handle Auth from API Gateway
-  const authorizer =
-    req.apiGateway &&
-    req.apiGateway.event &&
-    req.apiGateway.event.requestContext &&
-    req.apiGateway.event.requestContext.authorizer
-
-  /* istanbul ignore next */
-  if (authorizer) {
-    const { provider_id, scope } = authorizer
-    return { provider_id, scope }
-  }
-
-  // Handle Authorization Header when running standalone
-  const decode = ([scheme, token]: string[]): Partial<{ provider_id: string; scope: string }> => {
-    const decoders: { [scheme: string]: () => Partial<{ provider_id: string; scope: string }> } = {
-      bearer: () => {
-        const { provider_id, scope } = jwtDecode(token)
-        return { provider_id, scope }
-      },
-      basic: () => {
-        const [provider_id, scope] = Buffer.from(token, 'base64')
-          .toString()
-          .split('|')
-        return { provider_id, scope }
-      }
-    }
-    const decoder = decoders[scheme.toLowerCase()]
-    return decoder ? decoder() : {}
-  }
-
-  return req.headers.authorization ? decode(req.headers.authorization.split(' ')) : {}
-}
+import { ComplianceApiRequest, ComplianceApiResponse } from './types'
 
 function api(app: express.Express): express.Express {
-  app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+  app.use((req: ComplianceApiRequest, res: ComplianceApiResponse, next: express.NextFunction) => {
     try {
       // verify presence of provider_id
-      if (req.path.includes('/health')) {
-        // all auth provided by API Gateway
-      } else if (req.path !== '/') {
-        const { provider_id, scope } = getAuth(req)
+      if (!(req.path.includes('/health') || req.path === '/')) {
+        if (res.locals.claims) {
+          const { provider_id, scope } = res.locals.claims
 
-        // no test access without auth
-        if (req.path.includes('/test/')) {
-          if (!scope || !scope.includes('test:all')) {
-            return res.status(403).send({
-              result: `no test access without test:all scope (${scope})`
+          // no test access without auth
+          if (req.path.includes('/test/')) {
+            if (!scope || !scope.includes('test:all')) {
+              return res.status(403).send({
+                result: `no test access without test:all scope (${scope})`
+              })
+            }
+          }
+
+          // no admin access without auth
+          if (req.path.includes('/admin/')) {
+            if (!scope || !scope.includes('admin:all')) {
+              return res.status(403).send({
+                result: `no admin access without admin:all scope (${scope})`
+              })
+            }
+          }
+
+          /* istanbul ignore next */
+          if (!provider_id) {
+            log.warn('Missing provider_id in', req.originalUrl)
+            return res.status(400).send({
+              result: 'missing provider_id'
             })
           }
-        }
 
-        // no admin access without auth
-        if (req.path.includes('/admin/')) {
-          if (!scope || !scope.includes('admin:all')) {
-            return res.status(403).send({
-              result: `no admin access without admin:all scope (${scope})`
+          /* istanbul ignore next */
+          if (!isUUID(provider_id)) {
+            log.warn(req.originalUrl, 'invalid provider_id', provider_id)
+            return res.status(400).send({
+              result: `invalid provider_id ${provider_id} is not a UUID`
             })
           }
-        }
 
-        /* istanbul ignore next */
-        if (!provider_id) {
-          log.warn('Missing provider_id in', req.originalUrl)
-          return res.status(400).send({
-            result: 'missing provider_id'
-          })
-        }
+          // stash provider_id
+          res.locals.provider_id = provider_id
 
-        /* istanbul ignore next */
-        if (!isUUID(provider_id)) {
-          log.warn(req.originalUrl, 'invalid provider_id', provider_id)
-          return res.status(400).send({
-            result: `invalid provider_id ${provider_id} is not a UUID`
-          })
+          log.info(providerName(provider_id), req.method, req.originalUrl)
+        } else {
+          return res.status(401).send('Unauthorized')
         }
-        res.locals.provider_id = provider_id
       }
     } catch (err) {
       /* istanbul ignore next */
@@ -138,7 +108,7 @@ function api(app: express.Express): express.Express {
       )
   })
 
-  app.get(pathsFor('/snapshot/:policy_uuid'), async (req: express.Request, res: express.Response) => {
+  app.get(pathsFor('/snapshot/:policy_uuid'), async (req: ComplianceApiRequest, res: ComplianceApiResponse) => {
     if (![TEST1_PROVIDER_ID, TEST2_PROVIDER_ID].includes(res.locals.provider_id)) {
       res.status(401).send({ result: 'unauthorized access' })
     }
@@ -238,10 +208,8 @@ function api(app: express.Express): express.Express {
     }
   })
 
-  app.get(pathsFor('/count/:rule_id'), async (req: express.Request, res: express.Response) => {
-    if (
-      !['5f7114d1-4091-46ee-b492-e55875f7de00', '45f37d69-73ca-4ca6-a461-e7283cffa01a'].includes(res.locals.provider_id)
-    ) {
+  app.get(pathsFor('/count/:rule_id'), async (req: ComplianceApiRequest, res: ComplianceApiResponse) => {
+    if (!(res.locals.provider_id && [TEST1_PROVIDER_ID, TEST2_PROVIDER_ID].includes(res.locals.provider_id))) {
       res.status(401).send({ result: 'unauthorized access' })
     }
 

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -24,7 +24,6 @@
     "@hapi/joi": "15.1.0",
     "express": "4.17.1",
     "fs": "0.0.1-security",
-    "jwt-decode": "2.2.0",
     "mds-api-server": "0.1.0",
     "mds-cache": "0.1.0",
     "mds-db": "0.1.0",

--- a/packages/mds-compliance/types.ts
+++ b/packages/mds-compliance/types.ts
@@ -1,17 +1,11 @@
-import express from 'express'
+import { ApiRequest, ApiResponse } from 'mds-api-server'
+import { ApiAuthorizerClaims } from 'mds-api-authorizer'
 import { UUID } from 'mds'
 
-export interface ComplianceApiRequest extends express.Request {
-  apiGateway?: {
-    event?: {
-      requestContext?: {
-        authorizer?: Partial<{
-          principalId: string
-          provider_id: UUID
-          scope: string
-          email: string
-        }>
-      }
-    }
+export type ComplianceApiRequest = ApiRequest
+export interface ComplianceApiResponse extends ApiResponse {
+  locals: {
+    claims: ApiAuthorizerClaims
+    provider_id: UUID
   }
 }

--- a/packages/mds-daily/api.ts
+++ b/packages/mds-daily/api.ts
@@ -15,7 +15,6 @@
  */
 
 import express from 'express'
-import jwtDecode from 'jwt-decode'
 
 import log from 'mds-logger'
 import db from 'mds-db'
@@ -26,7 +25,7 @@ import areas from 'ladot-service-areas'
 import { UUID, VehicleEvent, CountMap, DeviceID, TripsStats } from 'mds'
 import { VEHICLE_EVENTS, VEHICLE_STATUSES, EVENT_STATUS_MAP } from 'mds-enums'
 import { isUUID, isTimestamp, now, days, inc, pathsFor, head, tail, isStateTransitionValid } from 'mds-utils'
-import { AgencyApiRequest } from 'mds-agency/types'
+import { DailyApiRequest, DailyApiResponse } from './types'
 
 const SERVER_ERROR = {
   error: 'server_error',
@@ -35,96 +34,54 @@ const SERVER_ERROR = {
 
 log.startup()
 
-// / ////////// utilities ////////////////
-
-/**
- * Extract auth info from JWT or auth headers
- */
-
-function getAuth(req: AgencyApiRequest): Partial<{ provider_id: string; scope: string }> {
-  // Handle Auth from API Gateway
-  const authorizer =
-    req.apiGateway &&
-    req.apiGateway.event &&
-    req.apiGateway.event.requestContext &&
-    req.apiGateway.event.requestContext.authorizer
-
-  /* istanbul ignore next */
-  if (authorizer) {
-    const { provider_id, scope } = authorizer
-    return { provider_id, scope }
-  }
-
-  // Handle Authorization Header when running standalone
-  const decode = ([scheme, token]: string[]): Partial<{ provider_id: string; scope: string }> => {
-    const decoders: { [scheme: string]: () => Partial<{ provider_id: string; scope: string }> } = {
-      bearer: () => {
-        const decoded: { [key: string]: string } = jwtDecode(token)
-        return {
-          provider_id: decoded['https://ladot.io/provider_id'],
-          scope: decoded.scope
-        }
-      },
-      basic: () => {
-        const [provider_id, scope] = Buffer.from(token, 'base64')
-          .toString()
-          .split('|')
-        return { provider_id, scope }
-      }
-    }
-    const decoder = decoders[scheme.toLowerCase()]
-    return decoder ? decoder() : {}
-  }
-
-  return req.headers.authorization ? decode(req.headers.authorization.split(' ')) : {}
-}
-
 function api(app: express.Express): express.Express {
   /**
    * Agency-specific middleware to extract provider_id into locals, do some logging, etc.
    */
-  app.use((req, res, next) => {
+  app.use((req: DailyApiRequest, res: DailyApiResponse, next) => {
     try {
       // verify presence of provider_id
-      if (req.path.includes('/health')) {
-        // all auth provided by API Gateway
-      } else if (req.path !== '/') {
-        const { provider_id, scope } = getAuth(req)
+      if (!(req.path.includes('/health') || req.path === '/')) {
+        if (res.locals.claims) {
+          const { provider_id, scope } = res.locals.claims
 
-        // no test access without auth
-        if (req.path.includes('/test/')) {
-          if (!scope || !scope.includes('test:all')) {
-            return res.status(403).send({
-              result: `no test access without test:all scope (${scope})`
-            })
+          // no test access without auth
+          if (req.path.includes('/test/')) {
+            if (!scope || !scope.includes('test:all')) {
+              return res.status(403).send({
+                result: `no test access without test:all scope (${scope})`
+              })
+            }
           }
+
+          // no admin access without auth
+          if (req.path.includes('/admin/')) {
+            if (!scope || !scope.includes('admin:all')) {
+              return res.status(403).send({
+                result: `no admin access without admin:all scope (${scope})`
+              })
+            }
+          }
+
+          if (provider_id) {
+            if (!isUUID(provider_id)) {
+              log.warn(req.originalUrl, 'bogus provider_id', provider_id)
+              return res.status(400).send({
+                result: `invalid provider_id ${provider_id} is not a UUID`
+              })
+            }
+
+            if (!isProviderId(provider_id)) {
+              return res.status(400).send({
+                result: `invalid provider_id ${provider_id} is not a known provider`
+              })
+            }
+
+            log.info(providerName(provider_id), req.method, req.originalUrl)
+          }
+        } else {
+          return res.status(401).send('Unauthorized')
         }
-
-        // no admin access without auth
-        if (req.path.includes('/admin/')) {
-          if (!scope || !scope.includes('admin:all')) {
-            return res.status(403).send({
-              result: `no admin access without admin:all scope (${scope})`
-            })
-          }
-        }
-
-        if (provider_id) {
-          if (!isUUID(provider_id)) {
-            log.warn(req.originalUrl, 'bogus provider_id', provider_id)
-            return res.status(400).send({
-              result: `invalid provider_id ${provider_id} is not a UUID`
-            })
-          }
-          if (!isProviderId(provider_id)) {
-            res.status(400).send({
-              result: `invalid provider_id ${provider_id} is not a known provider`
-            })
-          }
-        }
-
-        // stash provider_id
-        res.locals.provider_id = provider_id
       }
     } catch (err) {
       /* istanbul ignore next */
@@ -137,7 +94,7 @@ function api(app: express.Express): express.Express {
 
   // ///////////////////// begin daily endpoints ///////////////////////
 
-  app.get(pathsFor('/test/shutdown'), (req, res) => {
+  app.get(pathsFor('/test/shutdown'), (req: DailyApiRequest, res: DailyApiResponse) => {
     Promise.all([cache.shutdown(), stream.shutdown(), db.shutdown()]).then(() => {
       log.info('shutdown complete (in theory)')
       res.send({
@@ -201,7 +158,7 @@ function api(app: express.Express): express.Express {
     }
   }
 
-  app.get(pathsFor('/admin/vehicle_counts'), (req, res) => {
+  app.get(pathsFor('/admin/vehicle_counts'), (req: DailyApiRequest, res: DailyApiResponse) => {
     function fail(err: Error | string): void {
       log.error('/admin/vehicle_counts fail', err).then(() => {
         res.status(500).send({
@@ -301,7 +258,7 @@ function api(app: express.Express): express.Express {
   })
 
   // read all the latest events out of the cache
-  app.get(pathsFor('/admin/events'), (req, res) => {
+  app.get(pathsFor('/admin/events'), (req: DailyApiRequest, res: DailyApiResponse) => {
     cache.readAllEvents().then((events: VehicleEvent[]) => {
       res.status(200).send({
         events
@@ -359,7 +316,7 @@ function api(app: express.Express): express.Express {
     return perProvider
   }
 
-  app.get(pathsFor('/admin/last_day_trips_by_provider'), async (req, res) => {
+  app.get(pathsFor('/admin/last_day_trips_by_provider'), async (req: DailyApiRequest, res: DailyApiResponse) => {
     function fail(err: Error | string): void {
       log.error('last_day_trips_by_provider err:', err)
     }
@@ -401,7 +358,7 @@ function api(app: express.Express): express.Express {
   })
 
   // get raw trip data for analysis
-  app.get(pathsFor('/admin/raw_trip_data/:trip_id'), (req, res) => {
+  app.get(pathsFor('/admin/raw_trip_data/:trip_id'), (req: DailyApiRequest, res: DailyApiResponse) => {
     const { trip_id } = req.params
     db.readEvents({ trip_id })
       .then(
@@ -435,7 +392,7 @@ function api(app: express.Express): express.Express {
   // I didn't want to have to wrap everything in another Promise.then callback
   // by asking the DB for that information.
   // This function is ludicrously long as it is.
-  app.get(pathsFor('/admin/last_day_stats_by_provider'), (req, res) => {
+  app.get(pathsFor('/admin/last_day_stats_by_provider'), (req: DailyApiRequest, res: DailyApiResponse) => {
     const provider_info: {
       [p: string]: {
         name: string
@@ -592,7 +549,7 @@ function api(app: express.Express): express.Express {
       })
   })
 
-  app.get(pathsFor('/health'), (req, res) => {
+  app.get(pathsFor('/health'), (req: DailyApiRequest, res: DailyApiResponse) => {
     const health_info: { db?: object; stream?: object } = {}
     db.health()
       .then((result: object) => {

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -7,8 +7,6 @@
   "licence": "Apache-2.0",
   "dependencies": {
     "express": "4.17.1",
-    "jsonwebtoken": "8.5.1",
-    "jwt-decode": "2.2.0",
     "ladot-service-areas": "0.1.0",
     "mds-api-server": "0.1.0",
     "mds-cache": "0.1.0",

--- a/packages/mds-daily/server.ts
+++ b/packages/mds-daily/server.ts
@@ -19,7 +19,7 @@ import { server } from 'mds-api-server'
 import { api } from './api'
 
 const {
-  env: { npm_package_name, PORT = 4001 }
+  env: { npm_package_name, PORT = 4005 }
 } = process
 
 /* eslint-reason avoids import of logger */

--- a/packages/mds-daily/types.ts
+++ b/packages/mds-daily/types.ts
@@ -1,22 +1,9 @@
-import express from 'express'
 import { UUID } from 'mds'
 import { MultiPolygon } from 'geojson'
+import { ApiRequest, ApiResponse } from 'mds-api-server'
 
-// TODO this is same as ProviderApiRequest
-export interface AgencyApiRequest extends express.Request {
-  apiGateway?: {
-    event?: {
-      requestContext?: {
-        authorizer?: Partial<{
-          principalId: string
-          provider_id: UUID
-          scope: string
-          email: string
-        }>
-      }
-    }
-  }
-}
+export type DailyApiRequest = ApiRequest
+export type DailyApiResponse = ApiResponse
 
 export interface ServiceArea {
   service_area_id: UUID

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -13,7 +13,6 @@
     "@hapi/joi": "15.1.0",
     "express": "4.17.1",
     "joi-to-json-schema": "5.1.0",
-    "jwt-decode": "2.2.0",
     "mds-api-server": "0.1.0",
     "mds-db": "0.1.0",
     "mds-enums": "0.1.0",

--- a/packages/mds-policy/types.ts
+++ b/packages/mds-policy/types.ts
@@ -1,17 +1,4 @@
-import express from 'express'
-import { UUID } from 'mds'
+import { ApiRequest, ApiResponse } from 'mds-api-server'
 
-export interface PolicyApiRequest extends express.Request {
-  apiGateway?: {
-    event?: {
-      requestContext?: {
-        authorizer?: Partial<{
-          principalId: string
-          provider_id: UUID
-          scope: string
-          email: string
-        }>
-      }
-    }
-  }
-}
+export type PolicyApiRequest = ApiRequest
+export type PolicyApiResponse = ApiResponse

--- a/packages/mds-provider/tests/test.ts
+++ b/packages/mds-provider/tests/test.ts
@@ -228,11 +228,9 @@ describe('Tests app', () => {
   it('tries to get trips without authorization', done => {
     request
       .get('/trips')
-      .expect(403)
+      .expect(401)
       .end((err, result) => {
-        log.info('error:', result.body)
-        test.value(result).hasHeader('content-type', APP_JSON)
-        test.string(result.body.error).contains('missing_provider_id')
+        test.value(result.text).is('Unauthorized')
         done(err)
       })
   })


### PR DESCRIPTION
Each API implemented its own authorization header parser. Converted APIs to utilize the standard authorizer claims provided by `mds-api-authorizer` and `mds-api-server and removed of all the various and largely redundant `getAuth` functions.

## Impacts
- [x] Provider
- [x] Agency
- [x] Audit
- [x] Policy
- [x] Compliance

