### PR TITLE
[mds-agency][mds-provider] add register event

### DIFF
--- a/packages/mds-agency/tests/test.ts
+++ b/packages/mds-agency/tests/test.ts
@@ -89,7 +89,7 @@ let testTimestamp = now()
 
 const test_event = {
   device_id: DEVICE_UUID,
-  event_type: 'deregister',
+  event_type: VEHICLE_EVENTS.deregister,
   timestamp: testTimestamp
 }
 
@@ -668,7 +668,7 @@ describe('Tests API', () => {
           log('deregister readback event error', err)
         } else {
           // log('--- deregister readback event success', result.body)
-          test.object(result.body).match((obj: VehicleEvent) => obj.event_type === 'deregister')
+          test.object(result.body).match((obj: VehicleEvent) => obj.event_type === VEHICLE_EVENTS.deregister)
           test.object(result.body).match((obj: VehicleEvent) => obj.device_id === DEVICE_UUID)
         }
         done(err)

--- a/packages/mds-db/tests/mds-db.spec.ts
+++ b/packages/mds-db/tests/mds-db.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import { Telemetry, Recorded, VehicleEvent, Device } from 'mds'
+import { VEHICLE_EVENTS } from 'mds-enums'
 import {
   JUMP_TEST_DEVICE_1,
   makeDevices,
@@ -44,7 +45,7 @@ async function seedDB() {
     devices.slice(0, 9),
     startTime + 10,
     shapeUUID,
-    'deregister'
+    VEHICLE_EVENTS.deregister
   )
   const tripEndEvent: VehicleEvent[] = makeEventsWithTelemetry(
     devices.slice(9, 10),
@@ -160,10 +161,10 @@ if (pg_info.database) {
       it('.getEventCountsPerProviderSince', async () => {
         const result = await MDSDBPostgres.getEventCountsPerProviderSince()
         assert.deepEqual(result[0].provider_id, JUMP_PROVIDER_ID)
-        assert.deepEqual(result[0].event_type, 'deregister')
+        assert.deepEqual(result[0].event_type, VEHICLE_EVENTS.deregister)
         assert.deepEqual(result[0].count, 9)
         assert.deepEqual(result[1].provider_id, JUMP_PROVIDER_ID)
-        assert.deepEqual(result[1].event_type, 'trip_end')
+        assert.deepEqual(result[1].event_type, VEHICLE_EVENTS.trip_end)
         assert.deepEqual(result[1].count, 1)
       })
 

--- a/packages/mds-provider/tests/test.ts
+++ b/packages/mds-provider/tests/test.ts
@@ -16,7 +16,7 @@
 
 import supertest from 'supertest'
 import { now } from 'mds-utils'
-import { VEHICLE_TYPES, PROPULSION_TYPES } from 'mds-enums'
+import { VEHICLE_TYPES, PROPULSION_TYPES, VEHICLE_EVENTS } from 'mds-enums'
 import { PROVIDER_UUID, PROVIDER_AUTH, makeTelemetryStream, makeTelemetry, makeDevices } from 'mds-test-data'
 import test from 'unit.js'
 import { Device, Telemetry, VehicleEvent } from 'mds'
@@ -131,7 +131,7 @@ const test_deregister: VehicleEvent = {
   trip_id: null,
   device_id: DEVICE_UUID,
   provider_id: PROVIDER_UUID,
-  event_type: 'deregister',
+  event_type: VEHICLE_EVENTS.deregister,
   timestamp: test_timestamp,
   recorded: now()
 }

--- a/packages/mds-test-data/index.ts
+++ b/packages/mds-test-data/index.ts
@@ -192,7 +192,7 @@ function makeTelemetryStream(origin: Telemetry, steps: number) {
   return stream
 }
 
-function makeEvents(devices: Device[], timestamp: Timestamp, event_type = 'deregister'): VehicleEvent[] {
+function makeEvents(devices: Device[], timestamp: Timestamp, event_type = VEHICLE_EVENTS.deregister): VehicleEvent[] {
   if (!event_type) {
     throw new Error('empty event_type')
   }


### PR DESCRIPTION
Northbound Provider and other feeds should include a `register` event, per spec, but we will add that as part of the registration rather than asking providers to send a separate event