### PR TITLE
Use default export for services

### DIFF
--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -531,7 +531,7 @@ async function cleanup(deviceIdMap: { [device_id: string]: boolean }) {
   }
 }
 
-export = {
+export default {
   initialize,
   health,
   info,

--- a/packages/mds-db/index.ts
+++ b/packages/mds-db/index.ts
@@ -385,7 +385,7 @@ async function updateDevice(device_id: UUID, changes: Partial<Device>): Promise<
 
 async function writeEvent(event_param: VehicleEvent) {
   await readDevice(event_param.device_id)
-  const client = await getWriteableClient() 
+  const client = await getWriteableClient()
   const telemetry_timestamp = event_param.telemetry ? event_param.telemetry.timestamp : null
   const event = { ...event_param, telemetry_timestamp }
   const sql = `INSERT INTO ${cols_sql(schema.EVENTS_TABLE, schema.EVENTS_COLS)} ${vals_sql(schema.EVENTS_COLS)}`
@@ -1533,7 +1533,7 @@ async function seed(data: {
   return Promise.resolve('no data')
 }
 
-export = {
+export default {
   initialize,
   health,
   seed,

--- a/packages/mds-db/schema.ts
+++ b/packages/mds-db/schema.ts
@@ -216,7 +216,7 @@ const PG_TYPES: { [propName: string]: string } = {
   deleted: 'bigint'
 }
 
-export = {
+export default {
   DEVICES_TABLE,
   TELEMETRY_TABLE,
   EVENTS_TABLE,

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -237,4 +237,4 @@ async function startup() {
   // }
 }
 
-export = { info, warn, error, startup }
+export default { info, warn, error, startup }


### PR DESCRIPTION
While we should be using named exports, this PR simply replaces `export =` with the `export default` ... module consumption remains unchanged.

