### PR TITLE
[mds-*] support build on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "files": [
     "*",
-    "packages/*/dist"
+    "packages/*/dist/"
   ],
   "devDependencies": {
     "@types/bluebird": "3.5.27",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "aws-lambda/*",
     "packages/*"
   ],
+  "files": [
+    "*",
+    "packages/*/dist"
+  ],
   "devDependencies": {
     "@types/bluebird": "3.5.27",
     "@types/body-parser": "1.17.0",
@@ -55,6 +59,7 @@
   "types": "types/mds.d.ts",
   "dependencies": {},
   "scripts": {
+    "prepare": "yarn build",
     "build": "yarn run:concurrent build",
     "bundle": "yarn run:concurrent bundle",
     "clean": "git clean -fdX && yarn",


### PR DESCRIPTION
In order to use mds-core as a library, the importing module needs access to mds-core build artifacts under `dist` for each package.  But those build artifacts are not published anywhere at this time.

Short of publishing mds-core to a package registry, this PR implements the solution of using a `prepare` script to tell the importing library to build mds-core on install and put the build artifacts into node_modules/mds-core alongside the src.

A side effect of `prepare` is that it also gets run after every `yarn install` within mds-core.

In addition, a `files` include is used to workaround a yarn bug in which the prepare lifecycle script is not run for a git hosted dependency.
https://github.com/yarnpkg/yarn/issues/5235#issuecomment-490019287

## PR Checklist

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [x] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance

