### PR TITLE
[mds-*] reduce kms file handle consumption

### DIFF
--- a/aws-lambda/aws-utils/index.ts
+++ b/aws-lambda/aws-utils/index.ts
@@ -1,12 +1,14 @@
 import KMS from 'aws-sdk/clients/kms'
 
+const kms = new KMS()
+
 // Note: this will require the credentials in .aws/credentials
 // to be set. According to the AWS docs, the $AWS_REGION environment
 // variable should be set for Lambdas. To get this working locally, you will need to
 // export AWS_REGION='us-west-1'
+
 async function decrypt(cipherText: string): Promise<string> {
   try {
-    const kms = new KMS()
     const data = await kms.decrypt({ CiphertextBlob: Buffer.from(cipherText, 'base64') }).promise()
 
     if (!data || !data.Plaintext) {
@@ -15,6 +17,8 @@ async function decrypt(cipherText: string): Promise<string> {
       return data.Plaintext.toString('ascii')
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('KMS exception', err.message)
     throw err
   }
 }

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -347,7 +347,7 @@ function api(app: express.Express): express.Express {
       } catch (err) {
         await log.error('failed to write device stream/cache', err)
       }
-      await log.info('new', providerName(res.locals.provider_id), 'vehicle added', JSON.stringify(device))
+      await log.info('new', providerName(res.locals.provider_id), 'vehicle added', device)
       try {
         await writeRegisterEvent()
       } catch (err) {
@@ -503,7 +503,7 @@ function api(app: express.Express): express.Express {
           error: 'not_found'
         })
       } else {
-        await log.error(providerName(provider_id), `fail PUT /vehicles/${device_id}`, JSON.stringify(req.body), err)
+        await log.error(providerName(provider_id), `fail PUT /vehicles/${device_id}`, req.body, err)
         res.status(500).send(new ServerError())
       }
     }
@@ -1106,7 +1106,7 @@ function api(app: express.Express): express.Express {
           areas: {}
         }
       })
-      await log.warn('/admin/vehicle_counts', JSON.stringify(stats))
+      await log.warn('/admin/vehicle_counts', stats)
 
       const maps = await getMaps()
       const { eventMap } = maps
@@ -1491,7 +1491,7 @@ function api(app: express.Express): express.Express {
 
   app.get(pathsFor('/admin/cache/info'), async (req: AgencyApiRequest, res: AgencyApiResponse) => {
     const details = await cache.info()
-    await log.warn('cache', JSON.stringify(details))
+    await log.warn('cache', details)
     res.send(details)
   })
 
@@ -1526,7 +1526,7 @@ function api(app: express.Express): express.Express {
   async function refresh(device_id: UUID, provider_id: UUID): Promise<string> {
     // TODO all of this back and forth between cache and db is slow
     const device = await db.readDevice(device_id, provider_id)
-    // log.info('refresh device', JSON.stringify(device))
+    // log.info('refresh device', device)
     await cache.writeDevice(device)
     try {
       const event = await db.readEvent(device_id)
@@ -1553,7 +1553,7 @@ function api(app: express.Express): express.Express {
 
       await log.info('read', rows.length, 'device_ids. skip', skip, 'take', take)
       const devices = rows.slice(skip, take + skip)
-      await log.info('device_ids', JSON.stringify(devices))
+      await log.info('device_ids', devices)
 
       const promises = devices.map(device => refresh(device.device_id, device.provider_id))
       await Promise.all(promises)

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -807,7 +807,7 @@ function api(app: express.Express): express.Express {
             error_description: 'the specified device_id has not been registered'
           })
         } else {
-          await log.error('post event fail:', JSON.stringify(event), message)
+          await log.error('post event fail:', event, message)
           res.status(500).send(new ServerError())
         }
       }
@@ -831,12 +831,7 @@ function api(app: express.Express): express.Express {
         const failure = (await badEvent(event)) || (event.telemetry ? badTelemetry(event.telemetry) : null)
         // TODO unify with fail() above
         if (failure) {
-          await log.error(
-            providerName(res.locals.provider_id),
-            'event failure',
-            JSON.stringify(failure),
-            JSON.stringify(event)
-          )
+          await log.warn(name, 'event failure', failure, event)
           return res.status(400).send(failure)
         }
 

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -831,7 +831,7 @@ function api(app: express.Express): express.Express {
         const failure = (await badEvent(event)) || (event.telemetry ? badTelemetry(event.telemetry) : null)
         // TODO unify with fail() above
         if (failure) {
-          await log.warn(name, 'event failure', failure, event)
+          log.info(name, 'event failure', failure, event)
           return res.status(400).send(failure)
         }
 

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -181,36 +181,35 @@ async function readDevicesStatus(query: { since?: number; skip?: number; take?: 
   const start = query.since || 0
   const stop = now()
   // read all device ids
-  log
-    .info('redis zrangebyscore device-ids', start, stop)(await getClient())
-    .zrangebyscoreAsync('device-ids', start, stop)
-    .then(async (device_ids_res: string[]) => {
-      log.info('readDevicesStatus', device_ids_res.length, 'entries')
+  log.info('redis zrangebyscore device-ids', start, stop)
+  const client = await getClient()
+  client.zrangebyscoreAsync('device-ids', start, stop).then(async (device_ids_res: string[]) => {
+    log.info('readDevicesStatus', device_ids_res.length, 'entries')
 
-      const skip = query.skip || 0
-      const take = query.take || 100000000000
-      const device_ids = device_ids_res.slice(skip, skip + take)
+    const skip = query.skip || 0
+    const take = query.take || 100000000000
+    const device_ids = device_ids_res.slice(skip, skip + take)
 
-      // read all devices
-      const device_status_map: { [device_id: string]: CachedItem | {} } = {}
+    // read all devices
+    const device_status_map: { [device_id: string]: CachedItem | {} } = {}
 
-      // big batch redis nightmare!
-      let all: CachedItem[] = await hreads(['device', 'event', 'telemetry'], device_ids)
-      all = all.filter((item: CachedItem) => Boolean(item))
-      all.map(item => {
-        device_status_map[item.device_id] = device_status_map[item.device_id] || {}
-        Object.assign(device_status_map[item.device_id], item)
-      })
-      log.info('readDevicesStatus', device_ids.length, 'entries:', all.length)
-
-      let values = Object.values(device_status_map)
-      if (query.bbox) {
-        values = values.filter((status: CachedItem | {}) => insideBBox(status, query.bbox))
-      }
-
-      log.info('readDevicesStatus done')
-      return values
+    // big batch redis nightmare!
+    let all: CachedItem[] = await hreads(['device', 'event', 'telemetry'], device_ids)
+    all = all.filter((item: CachedItem) => Boolean(item))
+    all.map(item => {
+      device_status_map[item.device_id] = device_status_map[item.device_id] || {}
+      Object.assign(device_status_map[item.device_id], item)
     })
+    log.info('readDevicesStatus', device_ids.length, 'entries:', all.length)
+
+    let values = Object.values(device_status_map)
+    if (query.bbox) {
+      values = values.filter((status: CachedItem | {}) => insideBBox(status, query.bbox))
+    }
+
+    log.info('readDevicesStatus done')
+    return values
+  })
 }
 /* eslint-enable promise/catch-or-return */
 

--- a/packages/mds-db/sql-utils.ts
+++ b/packages/mds-db/sql-utils.ts
@@ -144,7 +144,7 @@ export async function logSql(sql: string, ...values: unknown[]): Promise<void> {
     out = values
   }
 
-  return log.info('sql>', sql, out)
+  log.info('sql>', sql, out)
 }
 
 export class SqlVals {

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -113,8 +113,10 @@ function makeCensoredLogMsgRecurse(msg: any): any {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeCensoredLogMsg(...msg: any[]) {
-  return makeCensoredLogMsgRecurse(msg)
+function makeCensoredLogMsg(...msgs: any[]): any[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const censored = msgs.map(msg => makeCensoredLogMsgRecurse(msg))
+  return censored.map(msg => (String(msg) === '[object Object]' ? JSON.stringify(msg) : msg))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -175,9 +177,9 @@ if (argv.length > 3) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function info(...msg: any) {
+function info(...msg: any[]): any[] {
   if (env.QUIET) {
-    return
+    return []
   }
 
   const censoredMsg = makeCensoredLogMsg(...msg)
@@ -186,29 +188,25 @@ function info(...msg: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function warn(...msg: any) {
-  try {
-    if (env.QUIET) {
-      return
-    }
-
-    const censoredMsg = makeCensoredLogMsg(...msg)
-    console.log.apply(console, ['WARN', ...censoredMsg])
-    /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-    await sendSlack(censoredMsg.join(' '))
-
-    /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
-    await sendPush(censoredMsg.join(' '), 0)
-    return censoredMsg
-  } catch (err) {
-    console.log(err)
+async function warn(...msg: any[]): Promise<any[]> {
+  if (env.QUIET) {
+    return []
   }
+
+  const censoredMsg = makeCensoredLogMsg(...msg)
+  console.log.apply(console, ['WARN', ...censoredMsg])
+  /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
+  await sendSlack(censoredMsg.join(' '))
+
+  /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
+  await sendPush(censoredMsg.join(' '), 0)
+  return censoredMsg
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function error(...msg: any) {
+async function error(...msg: any[]): Promise<any[]> {
   if (env.QUIET) {
-    return
+    return []
   }
   const censoredMsg = makeCensoredLogMsg(...msg)
   // eslint-disable-next-line no-console

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -116,7 +116,7 @@ function makeCensoredLogMsgRecurse(msg: any): any {
 function makeCensoredLogMsg(...msgs: any[]): any[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const censored = msgs.map(msg => makeCensoredLogMsgRecurse(msg))
-  return censored.map(msg => (String(msg) === '[object Object]' ? JSON.stringify(msg) : msg))
+  return censored.map(msg => (typeof msg === 'object' ? JSON.stringify(msg) : msg))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Move KMS object creation out of the decrypt() call, so it'll only be one per lambda

Change log.{info|warn|error} to use more sensible signature of `any[]`

Switch bad-event from `warn` to `info` to reduce slack spam

