### PR TITLE
Enable incremental builds using TypeScript project references

### DIFF
--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/aws-lambda/api-gateway-authorizer/tsconfig.build.json
+++ b/aws-lambda/api-gateway-authorizer/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [{ "path": "../../packages/mds-api-authorizer/tsconfig.build.json" }]
 }

--- a/aws-lambda/aws-serverless-express-handler/package.json
+++ b/aws-lambda/aws-serverless-express-handler/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/aws-lambda/aws-serverless-express-handler/tsconfig.build.json
+++ b/aws-lambda/aws-serverless-express-handler/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/api-gateway-authorizer/tsconfig.build.json" },
+    { "path": "../../aws-lambda/aws-utils/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/aws-utils/package.json
+++ b/aws-lambda/aws-utils/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/aws-lambda/aws-utils/tsconfig.build.json
+++ b/aws-lambda/aws-utils/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": []
 }

--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Agency API",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-agency": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-agency --zip-file fileb://dist/bundles/mds-agency.zip",
     "lambda:ladot-prod-mds-agency": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-agency --zip-file fileb://dist/bundles/mds-agency.zip",

--- a/aws-lambda/mds-agency/tsconfig.build.json
+++ b/aws-lambda/mds-agency/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-agency/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Audit API",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-audit": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-audit --zip-file fileb://dist/bundles/mds-audit.zip",
     "lambda:ladot-prod-mds-audit": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-audit --zip-file fileb://dist/bundles/mds-audit.zip",

--- a/aws-lambda/mds-audit/tsconfig.build.json
+++ b/aws-lambda/mds-audit/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-audit/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Compliance API",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-compliance": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-compliance --zip-file fileb://dist/bundles/mds-compliance.zip",
     "lambda:ladot-prod-mds-compliance": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-compliance --zip-file fileb://dist/bundles/mds-compliance.zip",

--- a/aws-lambda/mds-compliance/tsconfig.build.json
+++ b/aws-lambda/mds-compliance/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-compliance/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -5,7 +5,7 @@
   "description": "MDS daily-reports prototype",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-daily": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-daily --zip-file fileb://dist/bundles/mds-daily.zip",
     "lambda:ladot-prod-mds-daily": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-daily --zip-file fileb://dist/bundles/mds-daily.zip",

--- a/aws-lambda/mds-daily/tsconfig.build.json
+++ b/aws-lambda/mds-daily/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-daily/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/mds-metrics-sheet/package.json
+++ b/aws-lambda/mds-metrics-sheet/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Metrics Sheet",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-metrics-sheet": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-metrics-sheet --zip-file fileb://dist/bundles/metrics-log.zip",
     "lambda:dev3-metrics-sheet-geo": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-metrics-sheet-geo --zip-file fileb://dist/bundles/vehicle-counts.zip",

--- a/aws-lambda/mds-metrics-sheet/tsconfig.build.json
+++ b/aws-lambda/mds-metrics-sheet/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [{ "path": "../../packages/mds-metrics-sheet/tsconfig.build.json" }]
 }

--- a/aws-lambda/mds-native/package.json
+++ b/aws-lambda/mds-native/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Native API",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-native": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-native --zip-file fileb://dist/bundles/mds-native.zip",
     "lambda:ladot-prod-mds-native": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-native --zip-file fileb://dist/bundles/mds-native.zip",

--- a/aws-lambda/mds-native/tsconfig.build.json
+++ b/aws-lambda/mds-native/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-native/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Policy API",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-policy": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-policy --zip-file fileb://dist/bundles/mds-policy.zip",
     "lambda:ladot-prod-mds-policy": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-policy --zip-file fileb://dist/bundles/mds-policy.zip",

--- a/aws-lambda/mds-policy/tsconfig.build.json
+++ b/aws-lambda/mds-policy/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-policy/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -5,7 +5,7 @@
   "description": "AWS Lambda for MDS Provider API",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:dev3-mds-provider": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-provider --zip-file fileb://dist/bundles/mds-provider.zip",
     "lambda:ladot-prod-mds-provider": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-provider --zip-file fileb://dist/bundles/mds-provider.zip",

--- a/aws-lambda/mds-provider/tsconfig.build.json
+++ b/aws-lambda/mds-provider/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../aws-lambda/aws-serverless-express-handler/tsconfig.build.json" },
+    { "path": "../../packages/mds-provider/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -25,7 +25,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-agency/tsconfig.build.json
+++ b/packages/mds-agency/tsconfig.build.json
@@ -2,5 +2,17 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-helpers/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-stream/tsconfig.build.json" },
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-api-authorizer/package.json
+++ b/packages/mds-api-authorizer/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-api-authorizer/tsconfig.build.json
+++ b/packages/mds-api-authorizer/tsconfig.build.json
@@ -2,5 +2,9 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-api-helpers/package.json
+++ b/packages/mds-api-helpers/package.json
@@ -19,7 +19,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-api-helpers/tsconfig.build.json
+++ b/packages/mds-api-helpers/tsconfig.build.json
@@ -2,5 +2,11 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-api-server/package.json
+++ b/packages/mds-api-server/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-api-server/tsconfig.build.json
+++ b/packages/mds-api-server/tsconfig.build.json
@@ -2,5 +2,9 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-authorizer/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
@@ -22,7 +22,6 @@
   "author": "City of Los Angeles",
   "dependencies": {
     "express": "4.17.1",
-    "mds-api-authorizer": "0.1.3",
     "mds-api-helpers": "0.1.3",
     "mds-api-server": "0.1.3",
     "mds-cache": "0.1.3",

--- a/packages/mds-audit/tsconfig.build.json
+++ b/packages/mds-audit/tsconfig.build.json
@@ -2,5 +2,16 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-helpers/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-cache/package.json
+++ b/packages/mds-cache/package.json
@@ -20,7 +20,7 @@
     "redis": "2.8.0"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-cache/tsconfig.build.json
+++ b/packages/mds-cache/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
@@ -29,6 +29,7 @@
     "mds-db": "0.1.3",
     "mds-logger": "0.1.3",
     "mds-stream": "0.1.3",
+    "mds-types": "0.1.0",
     "mds-utils": "0.1.3",
     "moment-timezone": "0.5.26",
     "uuid4": "1.1.4",
@@ -38,7 +39,6 @@
     "mds-agency": "0.0.5",
     "mds-policy": "0.0.4",
     "mds-provider": "1.0.3",
-    "mds-types": "0.1.0",
     "mds-test-data": "0.1.3"
   }
 }

--- a/packages/mds-compliance/tsconfig.build.json
+++ b/packages/mds-compliance/tsconfig.build.json
@@ -2,5 +2,18 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-agency/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-policy/tsconfig.build.json" },
+    { "path": "../../packages/mds-provider/tsconfig.build.json" },
+    { "path": "../../packages/mds-stream/tsconfig.build.json" },
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -24,7 +24,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-daily/tsconfig.build.json
+++ b/packages/mds-daily/tsconfig.build.json
@@ -2,5 +2,16 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-stream/tsconfig.build.json" },
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-db/package.json
+++ b/packages/mds-db/package.json
@@ -9,7 +9,7 @@
     "database"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-db/tsconfig.build.json
+++ b/packages/mds-db/tsconfig.build.json
@@ -2,5 +2,10 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-logger/package.json
+++ b/packages/mds-logger/package.json
@@ -17,7 +17,7 @@
     "pushover-notifications": "1.2.0"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-logger/tsconfig.build.json
+++ b/packages/mds-logger/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": []
 }

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-metrics-sheet/tsconfig.build.json
+++ b/packages/mds-metrics-sheet/tsconfig.build.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "strict": false
+  "references": [
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-native/package.json
+++ b/packages/mds-native/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "express": "4.17.1",
-    "mds-api-server": "0.1.3",
     "mds-api-helpers": "0.1.3",
+    "mds-api-server": "0.1.3",
     "mds-db": "0.1.3",
     "mds-logger": "0.1.3",
     "mds-providers": "0.1.3",

--- a/packages/mds-native/tsconfig.build.json
+++ b/packages/mds-native/tsconfig.build.json
@@ -2,5 +2,14 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-helpers/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -24,7 +24,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-policy/tsconfig.build.json
+++ b/packages/mds-policy/tsconfig.build.json
@@ -2,5 +2,13 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "start": "yarn watch server",
     "stream": "yarn watch stream",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",

--- a/packages/mds-provider/tsconfig.build.json
+++ b/packages/mds-provider/tsconfig.build.json
@@ -2,5 +2,17 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-api-helpers/tsconfig.build.json" },
+    { "path": "../../packages/mds-api-server/tsconfig.build.json" },
+    { "path": "../../packages/mds-cache/tsconfig.build.json" },
+    { "path": "../../packages/mds-db/tsconfig.build.json" },
+    { "path": "../../packages/mds-logger/tsconfig.build.json" },
+    { "path": "../../packages/mds-providers/tsconfig.build.json" },
+    { "path": "../../packages/mds-stream/tsconfig.build.json" },
+    { "path": "../../packages/mds-test-data/tsconfig.build.json" },
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-providers/package.json
+++ b/packages/mds-providers/package.json
@@ -12,7 +12,7 @@
   "author": "City of Los Angeles",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-providers/tsconfig.build.json
+++ b/packages/mds-providers/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [{ "path": "../../packages/mds-types/tsconfig.build.json" }]
 }

--- a/packages/mds-stream/package.json
+++ b/packages/mds-stream/package.json
@@ -20,7 +20,7 @@
     "redis": "2.8.0"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-stream/tsconfig.build.json
+++ b/packages/mds-stream/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [{ "path": "../../packages/mds-types/tsconfig.build.json" }]
 }

--- a/packages/mds-test-data/package.json
+++ b/packages/mds-test-data/package.json
@@ -19,7 +19,7 @@
     "uuid4": "1.1.4"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"

--- a/packages/mds-test-data/tsconfig.build.json
+++ b/packages/mds-test-data/tsconfig.build.json
@@ -2,5 +2,9 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [
+    { "path": "../../packages/mds-types/tsconfig.build.json" },
+    { "path": "../../packages/mds-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/mds-types/package.json
+++ b/packages/mds-types/package.json
@@ -11,7 +11,7 @@
   "author": "City of Los Angeles",
   "license": "ISC",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-types/tsconfig.build.json
+++ b/packages/mds-types/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": []
 }

--- a/packages/mds-utils/package.json
+++ b/packages/mds-utils/package.json
@@ -18,7 +18,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",

--- a/packages/mds-utils/tsconfig.build.json
+++ b/packages/mds-utils/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist"
-  }
+  },
+  "references": [{ "path": "../../packages/mds-types/tsconfig.build.json" }]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
       "*": ["types/*", "*"]
     },
     "listEmittedFiles": true,
-    "declaration": true
+    "declaration": true,
+    "composite": true
   }
 }


### PR DESCRIPTION
Using `tsc --build` with project references provides a better watch mode experience.

