### PR TITLE
Add build date to about endpoint

### DIFF
--- a/aws-lambda/aws-serverless-express-handler/index.ts
+++ b/aws-lambda/aws-serverless-express-handler/index.ts
@@ -27,6 +27,7 @@ declare const NPM_PACKAGE_NAME: string
 declare const NPM_PACKAGE_VERSION: string
 declare const NPM_PACKAGE_GIT_BRANCH: string
 declare const NPM_PACKAGE_GIT_COMMIT: string
+declare const NPM_PACKAGE_BUILD_DATE: string
 
 export interface ApiGatewayRequest extends express.Request {
   apiGateway?: {
@@ -55,7 +56,8 @@ export const AwsServerlessExpressHandler = (
     npm_package_name: NPM_PACKAGE_NAME,
     npm_package_version: NPM_PACKAGE_VERSION,
     npm_package_git_branch: NPM_PACKAGE_GIT_BRANCH,
-    npm_package_git_commit: NPM_PACKAGE_GIT_COMMIT
+    npm_package_git_commit: NPM_PACKAGE_GIT_COMMIT,
+    npm_package_build_date: NPM_PACKAGE_BUILD_DATE
   })
 
   const server = awsServerlessExpress.createServer(

--- a/aws-lambda/webpack.config.js
+++ b/aws-lambda/webpack.config.js
@@ -45,7 +45,8 @@ module.exports = ({ env, argv, dirname, bundles }) => {
         NPM_PACKAGE_NAME: JSON.stringify(npm_package_name),
         NPM_PACKAGE_VERSION: JSON.stringify(npm_package_version),
         NPM_PACKAGE_GIT_BRANCH: JSON.stringify(gitRevisionPlugin.branch()),
-        NPM_PACKAGE_GIT_COMMIT: JSON.stringify(gitRevisionPlugin.commithash())
+        NPM_PACKAGE_GIT_COMMIT: JSON.stringify(gitRevisionPlugin.commithash()),
+        NPM_PACKAGE_BUILD_DATE: JSON.stringify(new Date().toISOString())
       }),
       // Zip the dist folder
       new ZipPlugin({

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -41,11 +41,14 @@ export const ApiServer = (
         npm_package_name: name,
         npm_package_version: version,
         npm_package_git_branch: branch,
-        npm_package_git_commit: commit
+        npm_package_git_commit: commit,
+        npm_package_build_date: date
       }
     } = process
     // 200 OK
-    res.status(200).send({ name, version, build: { branch, commit }, node })
+    res
+      .status(200)
+      .send({ name, version, build: branch && commit && date ? { date, branch, commit } : undefined, node })
   })
 
   app.get(pathsFor('/health'), async (req: ApiRequest, res: ApiResponse) => {


### PR DESCRIPTION
Adding the build date to the About (`/`) endpoint response:
```
{
  "name": "@aws-lambda/mds-audit",
  "version": "0.1.4",
  "build": {
    "date": "2019-07-23T15:20:46.971Z",
    "branch": "master",
    "commit": "605ce1b"
  },
  "node": "10.15.3"
}
```
Presently, the `build` property is not available when running locally. Will look at improving that subsequently.
