### PR TITLE
[mds-api-server] API Maintenance Mode

### DIFF
--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -42,18 +42,10 @@ export const ApiServer = (
   // Authorizer
   app.use((req: ApiRequest, res: ApiResponse, next: express.NextFunction) => {
     const { MAINTENANCE: maintenance } = process.env
-    res.locals.claims = authorizer(req)
     if (maintenance) {
-      if (req.method !== 'OPTIONS') {
-        if (
-          !pathsFor('/')
-            .concat(pathsFor('/health'))
-            .includes(req.path)
-        ) {
-          return res.status(503).send(about())
-        }
-      }
+      return res.status(503).send(about())
     }
+    res.locals.claims = authorizer(req)
     next()
   })
 

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -50,7 +50,7 @@ export const ApiServer = (
             .concat(pathsFor('/health'))
             .includes(req.path)
         ) {
-          return res.status(503).send({ maintenance })
+          return res.status(503).send(about())
         }
       }
     }

--- a/packages/mds-api-server/tests/index.spec.ts
+++ b/packages/mds-api-server/tests/index.spec.ts
@@ -105,7 +105,7 @@ describe('Testing API Server', () => {
       .expect(503)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)
-        test.object(result.body).hasProperty('maintenance', 'Testing')
+        test.object(result.body).hasProperty('status', 'Testing (MAINTENANCE)')
         done(err)
       })
   })

--- a/packages/mds-api-server/tests/index.spec.ts
+++ b/packages/mds-api-server/tests/index.spec.ts
@@ -49,7 +49,7 @@ describe('Testing API Server', () => {
     process.env.MAINTENANCE = 'Testing'
     request
       .get('/')
-      .expect(200)
+      .expect(503)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)
         test.object(result.body).hasProperty('name')
@@ -83,16 +83,16 @@ describe('Testing API Server', () => {
     process.env.MAINTENANCE = 'Testing'
     request
       .get('/health')
-      .expect(200)
+      .expect(503)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)
         test.object(result.body).hasProperty('name')
         test.object(result.body).hasProperty('version')
         test.object(result.body).hasProperty('node')
         test.object(result.body).hasProperty('build')
-        test.object(result.body).hasProperty('process')
-        test.object(result.body).hasProperty('memory')
-        test.object(result.body).hasProperty('uptime')
+        test.object(result.body).hasNotProperty('process')
+        test.object(result.body).hasNotProperty('memory')
+        test.object(result.body).hasNotProperty('uptime')
         test.object(result.body).hasProperty('status', 'Testing (MAINTENANCE)')
         done(err)
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,11 +2946,6 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-geo-distance@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/geo-distance/-/geo-distance-0.2.0.tgz#687bfa32ebb95a51438d219592388d74776b4418"
-  integrity sha512-FAWcCG6vhrfHIXMBipeNj1p6U4NucdlOMoTYrgRtFdudZEQjjrCDTYaw2Nh5go9MhjhY/RcZ+GVlAOa/dLDiVQ==
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"


### PR DESCRIPTION
Allow setting a `MAINTENANCE` environment variable to put an API in maintenance mode which will cause it to respond to all requests with `503 - Service Unavailable`

## Impacts
- [x] Provider
- [x] Agency
- [x] Audit
- [x] Policy
- [x] Compliance
- [x] Native

`MAINTENANCE=Database Migration` response to _ALL requests_:
<img width="412" alt="Screen Shot 2019-08-01 at 8 19 08 PM" src="https://user-images.githubusercontent.com/3439869/62335497-039b8d80-b49a-11e9-8a9a-c30fa469d514.png">

