### PR TITLE
[mds-cache] Switch a log.warn to log.info to avoid spamming slack for a cache miss

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -2,3 +2,6 @@ fileignoreconfig:
 - filename: yarn.lock
   checksum: 02a19fab10ddc762593b76e4aa5a4700cff5705a153a9acfe97467d2c9163068
   ignore_detectors: []
+- filename: packages/mds-cache/index.ts
+  checksum: 370d8215e861a9857fcca7b65057a7c14d39977d74857297225802c15284b4ff
+  ignore_detectors: []

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -268,7 +268,7 @@ async function updateProviderStats(suffix: string, device_id: UUID, timestamp: T
     )
   } catch (err) {
     const msg = `cannot updateProviderStats for unknown ${device_id}: ${err.message}`
-    await log.warn(msg)
+    await log.info(msg)
     return Promise.resolve(msg)
   }
 }


### PR DESCRIPTION
## PR Checklist

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
