### PR TITLE
Favor command line over require('dotenv') in code

### DIFF
--- a/aws-lambda/mds-agency/package.json
+++ b/aws-lambda/mds-agency/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-agency": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-agency --zip-file fileb://dist/bundles/mds-agency.zip",
     "lambda:ladot-prod-mds-agency": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-agency --zip-file fileb://dist/bundles/mds-agency.zip",
     "lambda:ladot-sandbox-mds-agency": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-agency --zip-file fileb://dist/bundles/mds-agency.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-audit/package.json
+++ b/aws-lambda/mds-audit/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-audit": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-audit --zip-file fileb://dist/bundles/mds-audit.zip",
     "lambda:ladot-prod-mds-audit": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-audit --zip-file fileb://dist/bundles/mds-audit.zip",
     "lambda:ladot-sandbox-mds-audit": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-audit --zip-file fileb://dist/bundles/mds-audit.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-compliance/package.json
+++ b/aws-lambda/mds-compliance/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-compliance": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-compliance --zip-file fileb://dist/bundles/mds-compliance.zip",
     "lambda:ladot-prod-mds-compliance": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-compliance --zip-file fileb://dist/bundles/mds-compliance.zip",
     "lambda:ladot-sandbox-mds-compliance": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-compliance --zip-file fileb://dist/bundles/mds-compliance.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-daily/package.json
+++ b/aws-lambda/mds-daily/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-daily": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-daily --zip-file fileb://dist/bundles/mds-daily.zip",
     "lambda:ladot-prod-mds-daily": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-daily --zip-file fileb://dist/bundles/mds-daily.zip",
     "lambda:ladot-sandbox-mds-daily": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-daily --zip-file fileb://dist/bundles/mds-daily.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-native/package.json
+++ b/aws-lambda/mds-native/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-native": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-native --zip-file fileb://dist/bundles/mds-native.zip",
     "lambda:ladot-prod-mds-native": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-native --zip-file fileb://dist/bundles/mds-native.zip",
     "lambda:ladot-sandbox-mds-native": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-native --zip-file fileb://dist/bundles/mds-native.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-policy/package.json
+++ b/aws-lambda/mds-policy/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-policy": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-policy --zip-file fileb://dist/bundles/mds-policy.zip",
     "lambda:ladot-prod-mds-policy": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-policy --zip-file fileb://dist/bundles/mds-policy.zip",
     "lambda:ladot-sandbox-mds-policy": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-policy --zip-file fileb://dist/bundles/mds-policy.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/aws-lambda/mds-provider/package.json
+++ b/aws-lambda/mds-provider/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-provider": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-provider --zip-file fileb://dist/bundles/mds-provider.zip",
     "lambda:ladot-prod-mds-provider": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-provider --zip-file fileb://dist/bundles/mds-provider.zip",
     "lambda:ladot-sandbox-mds-provider": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-provider --zip-file fileb://dist/bundles/mds-provider.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",
     "check-node-version": "4.0.1",
+    "dotenv": "8.0.0",
     "eslint": "6.1.0",
     "eslint-config-airbnb-base": "13.2.0",
     "eslint-config-prettier": "6.0.0",

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -1128,9 +1128,8 @@ function api(app: express.Express): express.Express {
     validateDeviceId,
     async (req: AgencyApiRequest, res: AgencyApiResponse) => {
       const { device_id } = req.params
-      let { timestamp } = req.params
 
-      timestamp = parseInt(timestamp) || undefined
+      const timestamp = parseInt(req.params.timestamp) || undefined
 
       const { cached } = req.query
 
@@ -1235,7 +1234,9 @@ function api(app: express.Express): express.Express {
     pathsFor('/test/vehicles/:device_id/telemetry/:timestamp'),
     validateDeviceId,
     async (req: AgencyApiRequest, res: AgencyApiResponse) => {
-      const { device_id, timestamp } = req.params
+      const { device_id } = req.params
+
+      const timestamp = parseInt(req.params.timestamp) || undefined
 
       try {
         const telemetry = await db.readTelemetry(device_id, timestamp, timestamp)

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -33,6 +33,6 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }
 }

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },
   "keywords": [
     "mds",

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -14,7 +14,7 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },
   "keywords": [
     "mds",

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -32,6 +32,6 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }
 }

--- a/packages/mds-logger/index.ts
+++ b/packages/mds-logger/index.ts
@@ -23,8 +23,6 @@ import PushClient from 'pushover-notifications'
 
 import { WebClient as SlackClient } from '@slack/client'
 
-require('dotenv').config()
-
 const { env } = process
 
 interface Datum {

--- a/packages/mds-logger/package.json
+++ b/packages/mds-logger/package.json
@@ -15,7 +15,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@slack/client": "5.0.2",
-    "dotenv": "8.0.0",
     "pushover-notifications": "1.2.0"
   },
   "scripts": {

--- a/packages/mds-metrics-sheet/metrics-log.ts
+++ b/packages/mds-metrics-sheet/metrics-log.ts
@@ -32,8 +32,6 @@ import {
 import { VEHICLE_EVENT, EVENT_STATUS_MAP, VEHICLE_STATUS } from '@mds-core/mds-types'
 import { VehicleCountResponse, LastDayStatsResponse, MetricsSheetRow } from './types'
 
-require('dotenv').config()
-
 // The list of providers ids on which to report
 const reportProviders = [
   JUMP_PROVIDER_ID,

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -19,7 +19,6 @@
     "@mds-core/mds-logger": "^0.1.4",
     "@mds-core/mds-providers": "^0.1.4",
     "@mds-core/mds-types": "^0.1.1",
-    "dotenv": "8.0.0",
     "google-spreadsheet": "2.0.7",
     "request": "2.88.0",
     "request-promise": "4.2.4"

--- a/packages/mds-metrics-sheet/vehicle-counts.ts
+++ b/packages/mds-metrics-sheet/vehicle-counts.ts
@@ -34,8 +34,6 @@ import {
 
 import { VehicleCountResponse } from './types'
 
-require('dotenv').config()
-
 // The list of providers ids on which to report
 const reportProviders = [
   JUMP_PROVIDER_ID,

--- a/packages/mds-native/package.json
+++ b/packages/mds-native/package.json
@@ -16,7 +16,7 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },
   "dependencies": {
     "@mds-core/mds-api-helpers": "^0.1.4",

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -32,6 +32,6 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }
 }

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -17,7 +17,7 @@
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },
   "dependencies": {
     "@mds-core/mds-api-helpers": "^0.1.4",


### PR DESCRIPTION
I noticed a few places in the code (metrics sheets and logger) were doing `require('dotenv').config()`. Preloading is generally the preferred approach because this method of setting environment variables is typically only used during development. `.env` files are generally not recommended in CI/CD or Production.

Also, removed some legacy npm scripts that are no longer functional.