### PR TITLE
[mds-cache] Instead of attempting to look up the provider_id, simply provider it as a function param.

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -3,5 +3,5 @@ fileignoreconfig:
   checksum: 02a19fab10ddc762593b76e4aa5a4700cff5705a153a9acfe97467d2c9163068
   ignore_detectors: []
 - filename: packages/mds-cache/index.ts
-  checksum: 59bcbd7c8910c9746a35833642e72faad8bddeaf5ad7a3e7a60d985c6a1a4fb2
+  checksum: 06b46599cd5919db7f709d9dc681aa902701492c62bfb9df9259859736c06c9e
   ignore_detectors: []

--- a/.talismanrc
+++ b/.talismanrc
@@ -3,5 +3,5 @@ fileignoreconfig:
   checksum: 02a19fab10ddc762593b76e4aa5a4700cff5705a153a9acfe97467d2c9163068
   ignore_detectors: []
 - filename: packages/mds-cache/index.ts
-  checksum: 370d8215e861a9857fcca7b65057a7c14d39977d74857297225802c15284b4ff
+  checksum: 59bcbd7c8910c9746a35833642e72faad8bddeaf5ad7a3e7a60d985c6a1a4fb2
   ignore_detectors: []

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -252,15 +252,14 @@ async function readDevicesStatus(query: { since?: number; skip?: number; take?: 
   return values.filter((item: any) => item.telemetry)
 }
 
-// get the provider for a device
-async function getProviderId(device_id: UUID) {
-  return (await readDevice(device_id)).provider_id
-}
-
 // initial set of stats are super-simple: last-written values for device, event, and telemetry
-async function updateProviderStats(suffix: string, device_id: UUID, timestamp: Timestamp | undefined | null) {
+async function updateProviderStats(
+  suffix: string,
+  device_id: UUID,
+  timestamp: Timestamp | undefined | null,
+  provider_id: UUID
+) {
   try {
-    const provider_id = await getProviderId(device_id)
     return (await getClient()).hmsetAsync(
       `provider:${provider_id}:stats`,
       `last${capitalizeFirst(suffix)}`,
@@ -279,7 +278,7 @@ async function hwrite(suffix: string, item: CacheReadDeviceResult | Telemetry | 
     await log.error(`hwrite: invalid device_id ${item.device_id}`)
     throw new Error(`hwrite: invalid device_id ${item.device_id}`)
   }
-  const { device_id } = item
+  const { device_id, provider_id } = item
   const key = `device:${device_id}:${suffix}`
   const flat: { [key: string]: unknown } = flatten(item)
   const nulls = nullKeys(flat)
@@ -298,14 +297,14 @@ async function hwrite(suffix: string, item: CacheReadDeviceResult | Telemetry | 
       // make sure the device list is updated (per-provider)
       updateVehicleList(device_id, item.timestamp),
       // update last-written values
-      updateProviderStats(suffix, device_id, item.timestamp)
+      updateProviderStats(suffix, device_id, item.timestamp, provider_id)
     ])
   }
   return Promise.all([
     // make sure the device list is updated (per-provider)
     updateVehicleList(device_id),
     // update last-written values
-    updateProviderStats(suffix, device_id, null)
+    updateProviderStats(suffix, device_id, null, provider_id)
   ])
 }
 

--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -253,12 +253,7 @@ async function readDevicesStatus(query: { since?: number; skip?: number; take?: 
 }
 
 // initial set of stats are super-simple: last-written values for device, event, and telemetry
-async function updateProviderStats(
-  suffix: string,
-  device_id: UUID,
-  timestamp: Timestamp | undefined | null,
-  provider_id: UUID
-) {
+async function updateProviderStats(suffix: string, device_id: UUID, provider_id: UUID, timestamp?: Timestamp) {
   try {
     return (await getClient()).hmsetAsync(
       `provider:${provider_id}:stats`,
@@ -297,14 +292,14 @@ async function hwrite(suffix: string, item: CacheReadDeviceResult | Telemetry | 
       // make sure the device list is updated (per-provider)
       updateVehicleList(device_id, item.timestamp),
       // update last-written values
-      updateProviderStats(suffix, device_id, item.timestamp, provider_id)
+      updateProviderStats(suffix, device_id, provider_id, item.timestamp)
     ])
   }
   return Promise.all([
     // make sure the device list is updated (per-provider)
     updateVehicleList(device_id),
     // update last-written values
-    updateProviderStats(suffix, device_id, null, provider_id)
+    updateProviderStats(suffix, device_id, provider_id)
   ])
 }
 


### PR DESCRIPTION
## PR Checklist

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [x] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance