### PR TITLE
[mds-db] Control automatic migrations with env var

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -5,3 +5,6 @@ fileignoreconfig:
 - filename: packages/mds-cache/index.ts
   checksum: 370d8215e861a9857fcca7b65057a7c14d39977d74857297225802c15284b4ff
   ignore_detectors: []
+- filename: packages/mds-db/index.ts
+  checksum: 73a8e69b88bc3132483fe9cf49b1fcce2599bf8093e6ddd54588925d174a1f0f
+  ignore_detectors: []

--- a/packages/mds-db/index.ts
+++ b/packages/mds-db/index.ts
@@ -62,7 +62,7 @@ let writeableCachedClient: MDSPostgresClient | null = null
 let readOnlyCachedClient: MDSPostgresClient | null = null
 
 async function setupClient(useWriteable: boolean): Promise<MDSPostgresClient> {
-  const { PG_NAME, PG_USER, PG_PASS, PG_PORT } = env
+  const { PG_NAME, PG_USER, PG_PASS, PG_PORT, PG_MIGRATIONS = 'false' } = env
   let PG_HOST: string | undefined
   if (useWriteable) {
     ;({ PG_HOST } = env)
@@ -84,7 +84,9 @@ async function setupClient(useWriteable: boolean): Promise<MDSPostgresClient> {
   try {
     await client.connect()
     if (useWriteable) {
-      await updateSchema(client)
+      if (PG_MIGRATIONS === 'true') {
+        await updateSchema(client)
+      }
     }
     log.info(
       'connected',


### PR DESCRIPTION
Don't automatically create tables and run migrations unless the environment variable `PG_MIGRATIONS` is `'true'`. This allows some control over when (and via which API) migrations are run. 

