### PR TITLE
[mds-native] Providers List Endpoint

### DIFF
--- a/aws-lambda/mds-policy-author/package.json
+++ b/aws-lambda/mds-policy-author/package.json
@@ -12,12 +12,9 @@
     "lambda:dev3-mds-policy-author": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name dev3-mds-policy-author --zip-file fileb://dist/bundles/mds-policy-author.zip",
     "lambda:ladot-prod-mds-policy-author": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-policy-author --zip-file fileb://dist/bundles/mds-policy-author.zip",
     "lambda:ladot-sandbox-mds-policy-author": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-policy-author --zip-file fileb://dist/bundles/mds-policy-author.zip",
-    "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0",
-    "watch": "nodemon --watch '../../aws-lambda' --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
-    "watch:exec": "yarn build && ts-node"
+    "test:unit": "exit 0"
   },
   "keywords": [
     "mds"

--- a/packages/mds-agency/package.json
+++ b/packages/mds-agency/package.json
@@ -28,10 +28,10 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/agency yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/agency nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-agency/tests/test.ts
+++ b/packages/mds-agency/tests/test.ts
@@ -44,8 +44,6 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { TEST1_PROVIDER_ID, TEST2_PROVIDER_ID } from '@mds-core/mds-providers'
 import { api } from '../api'
 
-process.env.PATH_PREFIX = '/agency'
-
 /* eslint-disable-next-line no-console */
 const log = console.log.bind(console)
 

--- a/packages/mds-audit/package.json
+++ b/packages/mds-audit/package.json
@@ -9,10 +9,10 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/audit yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/audit nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-audit/tests/api.spec.ts
+++ b/packages/mds-audit/tests/api.spec.ts
@@ -47,8 +47,6 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import db from '@mds-core/mds-db'
 import { api } from '../api'
 
-process.env.PATH_PREFIX = '/audit'
-
 const request = supertest(ApiServer(api))
 
 const PROVIDER_SCOPES = 'admin:all test:all'

--- a/packages/mds-compliance/package.json
+++ b/packages/mds-compliance/package.json
@@ -9,10 +9,10 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/compliance yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/compliance nyc --check-coverage --exclude tests --extension .ts --lines 90 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-compliance/tests/api.spec.ts
+++ b/packages/mds-compliance/tests/api.spec.ts
@@ -63,7 +63,6 @@ const TEST_TELEMETRY = {
 }
 
 process.env.TIMEZONE = 'America/Los_Angeles'
-process.env.PATH_PREFIX = '/compliance'
 const PROVIDER_SCOPES = 'admin:all test:all'
 const ADMIN_AUTH = `basic ${Buffer.from(`${TEST1_PROVIDER_ID}|${PROVIDER_SCOPES}`).toString('base64')}`
 const AUTH_ADMIN_ONLY_SCOPE = `basic ${Buffer.from(`${TEST1_PROVIDER_ID}|admin:all`).toString('base64')}`

--- a/packages/mds-daily/package.json
+++ b/packages/mds-daily/package.json
@@ -27,10 +27,10 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/agency yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/agency nyc --check-coverage --exclude tests --extension .ts --lines 55 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-daily/tests/test.ts
+++ b/packages/mds-daily/tests/test.ts
@@ -36,8 +36,6 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { TEST1_PROVIDER_ID } from '@mds-core/mds-providers'
 import { api } from '../api'
 
-process.env.PATH_PREFIX = '/agency'
-
 /* eslint-disable-next-line no-console */
 const log = console.log.bind(console)
 

--- a/packages/mds-native/api.ts
+++ b/packages/mds-native/api.ts
@@ -28,7 +28,8 @@ import {
 } from '@mds-core/mds-utils'
 import logger from '@mds-core/mds-logger'
 import db from '@mds-core/mds-db'
-import { UUID, Timestamp } from 'packages/mds-types'
+import { UUID, Timestamp } from '@mds-core/mds-types'
+import { providers } from '@mds-core/mds-providers'
 
 import {
   NativeApiResponse,
@@ -36,7 +37,9 @@ import {
   NativeApiGetEventsRequest,
   NativeApiGetEventsReponse,
   NativeApiGetDeviceRequest,
-  NativeApiGetDeviceResponse
+  NativeApiGetDeviceResponse,
+  NativeApiGetProvidersRequest,
+  NativeApiGetProvidersResponse
 } from './types'
 
 const NATIVE_API_VERSION = '0.0.1'
@@ -126,7 +129,7 @@ function api(app: express.Express): express.Express {
           cursor: JSON.parse(Buffer.from(cursor, 'base64').toString('ascii')),
           limit: Number(limit)
         }
-      } catch (err) /* istanbul ignore next */ {
+      } catch (err) {
         throw new ValidationError('invalid_cursor', { cursor })
       }
     } else {
@@ -161,7 +164,7 @@ function api(app: express.Express): express.Express {
         ).toString('base64'),
         events: events.map(({ service_area_id, ...event }) => event)
       })
-    } catch (err) /* istanbul ignore next */ {
+    } catch (err) {
       if (err instanceof ValidationError) {
         await logger.warn(req.method, req.originalUrl, err)
         return res.status(400).send({ error: err })
@@ -193,6 +196,13 @@ function api(app: express.Express): express.Express {
       return res.status(500).send({ error: new ServerError(err) })
     }
   })
+
+  app.get(pathsFor('/providers'), async (req: NativeApiGetProvidersRequest, res: NativeApiGetProvidersResponse) =>
+    res.status(200).send({
+      version: NATIVE_API_VERSION,
+      providers: Object.values(providers)
+    })
+  )
 
   return app
 }

--- a/packages/mds-native/api.ts
+++ b/packages/mds-native/api.ts
@@ -44,6 +44,13 @@ import {
 
 const NATIVE_API_VERSION = '0.0.1'
 
+/* istanbul ignore next */
+const InternalServerError = async <T>(req: NativeApiRequest, res: NativeApiResponse<T>, err?: string | Error) => {
+  // 500 Internal Server Error
+  await logger.error(req.method, req.originalUrl, err)
+  return res.status(500).send({ error: new ServerError(err) })
+}
+
 function api(app: express.Express): express.Express {
   // ///////////////////// begin middleware ///////////////////////
   app.use(async (req: NativeApiRequest, res: NativeApiResponse, next: express.NextFunction) => {
@@ -59,13 +66,8 @@ function api(app: express.Express): express.Express {
           return res.status(401).send({ error: new AuthorizationError('missing_claims') })
         }
       } catch (err) {
-        if (err instanceof ValidationError) {
-          // 400 Bad Request
-          return res.status(400).send({ error: err })
-        }
-        // 500 Internal Server Error
-        await logger.error(`fail ${req.method} ${req.originalUrl}`, err.stack || JSON.stringify(err))
-        return res.status(500).send({ error: new ServerError(err) })
+        /* istanbul ignore next */
+        return InternalServerError(req, res, err)
       }
     }
     logger.info(req.method, req.originalUrl)
@@ -82,10 +84,9 @@ function api(app: express.Express): express.Express {
       await logger.info(result)
       // 200 OK
       return res.status(200).send({ result })
-    } catch (err) /* istanbul ignore next */ {
-      // 500 Internal Server Error
-      await logger.error(`fail ${req.method} ${req.originalUrl}`, err.stack || JSON.stringify(err))
-      return res.status(500).send({ error: new ServerError(err) })
+    } catch (err) {
+      /* istanbul ignore next */
+      return InternalServerError(req, res, err)
     }
   })
 
@@ -96,10 +97,9 @@ function api(app: express.Express): express.Express {
       await logger.info(result)
       // 200 OK
       return res.status(200).send({ result })
-    } catch (err) /* istanbul ignore next */ {
-      // 500 Internal Server Error
-      await logger.error(`fail ${req.method} ${req.originalUrl}`, err.stack || JSON.stringify(err))
-      return res.status(500).send({ error: new ServerError(err) })
+    } catch (err) {
+      /* istanbul ignore next */
+      return InternalServerError(req, res, err)
     }
   })
   // ///////////////////// end test-only endpoints ///////////////////////
@@ -169,9 +169,8 @@ function api(app: express.Express): express.Express {
         await logger.warn(req.method, req.originalUrl, err)
         return res.status(400).send({ error: err })
       }
-      // 500 Internal Server Error
-      await logger.error(req.method, req.originalUrl, err)
-      return res.status(500).send({ error: new ServerError(err) })
+      /* istanbul ignore next */
+      return InternalServerError(req, res, err)
     }
   })
 
@@ -191,9 +190,8 @@ function api(app: express.Express): express.Express {
         // 404 Not Found
         return res.status(404).send({ error: new NotFoundError('device_id_not_found', { device_id }) })
       }
-      // 500 Internal Server Error
-      await logger.error(req.method, req.originalUrl, err)
-      return res.status(500).send({ error: new ServerError(err) })
+      /* istanbul ignore next */
+      return InternalServerError(req, res, err)
     }
   })
 

--- a/packages/mds-native/package.json
+++ b/packages/mds-native/package.json
@@ -11,10 +11,10 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/native yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/native nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-native/tests/api.spec.ts
+++ b/packages/mds-native/tests/api.spec.ts
@@ -10,6 +10,7 @@ import test from 'unit.js'
 import db from '@mds-core/mds-db'
 import { ApiServer } from '@mds-core/mds-api-server'
 import { PROVIDER_UUID } from '@mds-core/mds-test-data'
+import { providers } from '@mds-core/mds-providers'
 import uuid from 'uuid'
 import { PROPULSION_TYPES, VEHICLE_TYPES } from '@mds-core/mds-types'
 import { api } from '../api'
@@ -180,6 +181,20 @@ describe('Verify API', () => {
       .expect(400)
       .end((err, result) => {
         test.value(result).hasHeader('content-type', APP_JSON)
+        done(err)
+      })
+  })
+
+  it('Get Providers', done => {
+    request
+      .get(`/native/providers`)
+      .set('Authorization', PROVIDER_AUTH)
+      .expect(200)
+      .end((err, result) => {
+        test.value(result).hasHeader('content-type', APP_JSON)
+        test.object(result.body).hasProperty('version')
+        test.object(result.body).hasProperty('providers')
+        test.value(result.body.providers.length).is(Object.keys(providers).length)
         done(err)
       })
   })

--- a/packages/mds-native/tests/api.spec.ts
+++ b/packages/mds-native/tests/api.spec.ts
@@ -14,7 +14,6 @@ import uuid from 'uuid'
 import { PROPULSION_TYPES, VEHICLE_TYPES } from '@mds-core/mds-types'
 import { api } from '../api'
 
-process.env.PATH_PREFIX = '/native'
 const PROVIDER_SCOPES = 'admin:all test:all'
 const PROVIDER_AUTH = `basic ${Buffer.from(`${PROVIDER_UUID}|`).toString('base64')}`
 const ADMIN_AUTH = `basic ${Buffer.from(`${PROVIDER_UUID}|${PROVIDER_SCOPES}`).toString('base64')}`

--- a/packages/mds-native/types.ts
+++ b/packages/mds-native/types.ts
@@ -16,7 +16,7 @@
 
 import { ApiRequest, ApiResponse } from '@mds-core/mds-api-server'
 import { ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
-import { UUID, VehicleEvent, Recorded, Device } from '@mds-core/mds-types'
+import { UUID, VehicleEvent, Recorded, Device, Provider } from '@mds-core/mds-types'
 
 // Allow adding type definitions for Express Request objects
 export type NativeApiRequest = ApiRequest
@@ -54,4 +54,11 @@ export interface NativeApiGetDeviceRequest extends NativeApiRequest {
 export type NativeApiGetDeviceResponse = NativeApiResponse<{
   version: string
   device: Device
+}>
+
+export type NativeApiGetProvidersRequest = NativeApiRequest
+
+export type NativeApiGetProvidersResponse = NativeApiResponse<{
+  version: string
+  providers: Provider[]
 }>

--- a/packages/mds-policy-author/package.json
+++ b/packages/mds-policy-author/package.json
@@ -24,11 +24,11 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/policy yarn watch server",
     "test": "yarn test:prettier && yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --ignore-path ../../.gitignore '**/*.ts'",
     "test:prettier": "prettier --write --check --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/policy nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && ts-node"
   }

--- a/packages/mds-policy-author/tests/api.spec.ts
+++ b/packages/mds-policy-author/tests/api.spec.ts
@@ -44,8 +44,6 @@ import {
 } from '@mds-core/mds-test-data'
 import { api } from '../api'
 
-process.env.PATH_PREFIX = '/policy'
-
 /* eslint-disable-next-line no-console */
 const log = console.log.bind(console)
 

--- a/packages/mds-policy/package.json
+++ b/packages/mds-policy/package.json
@@ -27,10 +27,10 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/policy yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/policy nyc --check-coverage --exclude tests --extension .ts --lines 80 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   }

--- a/packages/mds-policy/tests/api.spec.ts
+++ b/packages/mds-policy/tests/api.spec.ts
@@ -44,8 +44,6 @@ import { api } from '../api'
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const veniceSpecialOpsZone = require('../../ladot-service-areas/venice-special-ops-zone')
 
-process.env.PATH_PREFIX = '/policy'
-
 /* eslint-disable-next-line no-console */
 const log = console.log.bind(console)
 

--- a/packages/mds-provider/package.json
+++ b/packages/mds-provider/package.json
@@ -11,11 +11,11 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "start": "yarn watch server",
+    "start": "PATH_PREFIX=/provider yarn watch server",
     "stream": "yarn watch stream",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
+    "test:unit": "PATH_PREFIX=/policy nyc --check-coverage --exclude tests --extension .ts --lines 85 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --recursive tests/**/*.ts",
     "watch": "nodemon --watch '../../packages' --ext 'ts' --ignore '*.d.ts' --exec yarn watch:exec --",
     "watch:exec": "yarn build && DOTENV_CONFIG_PATH=../../.env ts-node -r dotenv/config"
   },

--- a/packages/mds-provider/tests/status-changes.spec.ts
+++ b/packages/mds-provider/tests/status-changes.spec.ts
@@ -5,7 +5,7 @@ import {
   PROVIDER_EVENTS,
   VEHICLE_REASONS,
   VEHICLE_EVENT
-} from 'packages/mds-types'
+} from '@mds-core/mds-types'
 import { StatusChangeEvent } from '@mds-core/mds-db/types'
 import test from 'unit.js'
 import { asStatusChangeEvent } from '../utils'

--- a/packages/mds-provider/tests/test.ts
+++ b/packages/mds-provider/tests/test.ts
@@ -30,8 +30,6 @@ import log from '@mds-core/mds-logger'
 import { api } from '../api'
 import { ProviderEventProcessor } from '../event-processor'
 
-process.env.PATH_PREFIX = '/provider'
-
 const APP_JSON = 'application/json; charset=utf-8'
 
 const request = supertest(ApiServer(api))

--- a/packages/mds-providers/index.ts
+++ b/packages/mds-providers/index.ts
@@ -54,105 +54,126 @@ type PROVIDER_ID = typeof PROVIDER_IDS[number]
 
 export const providers: Readonly<{ [P in PROVIDER_ID]: Readonly<Provider> }> = Object.freeze({
   [JUMP_PROVIDER_ID]: Object.freeze({
+    provider_id: JUMP_PROVIDER_ID,
     provider_name: 'JUMP',
     url: 'https://jump.com',
     mds_api_url: 'https://api.uber.com/v0.2/emobility/mds'
   }),
   [LIME_PROVIDER_ID]: Object.freeze({
+    provider_id: LIME_PROVIDER_ID,
     provider_name: 'Lime',
     url: 'https://li.me',
     mds_api_url: 'https://data.lime.bike/api/partners/v1/mds'
   }),
   [BIRD_PROVIDER_ID]: Object.freeze({
+    provider_id: BIRD_PROVIDER_ID,
     provider_name: 'Bird',
     url: 'https://www.bird.co',
     mds_api_url: 'https://mds.bird.co',
     gbfs_api_url: 'https://mds.bird.co/gbfs'
   }),
   [RAZOR_PROVIDER_ID]: Object.freeze({
+    provider_id: RAZOR_PROVIDER_ID,
     provider_name: 'Razor',
     url: 'https: //www.razor.com/share',
     mds_api_url: 'https: //razor-200806.appspot.com/api/v2/mds'
   }),
   [LYFT_PROVIDER_ID]: Object.freeze({
+    provider_id: LYFT_PROVIDER_ID,
     provider_name: 'Lyft',
     url: 'https://www.lyft.com',
     mds_api_url: 'https: //api.lyft.com/v1/last-mile/mds'
   }),
   [SKIP_PROVIDER_ID]: Object.freeze({
+    provider_id: SKIP_PROVIDER_ID,
     provider_name: 'Skip',
     url: 'https://www.skipscooters.com',
     mds_api_url: 'https://api.skipscooters.com/mds'
   }),
   [HOPR_PROVIDER_ID]: Object.freeze({
+    provider_id: HOPR_PROVIDER_ID,
     provider_name: 'HOPR',
     url: 'https://gohopr.com',
     mds_api_url: 'https://gbfs.hopr.city/api/mds'
   }),
   [WHEELS_PROVIDER_ID]: Object.freeze({
+    provider_id: WHEELS_PROVIDER_ID,
     provider_name: 'Wheels',
     url: 'https://wheels.co',
     mds_api_url: 'https://mds.getwheelsapp.com'
   }),
   [SPIN_PROVIDER_ID]: Object.freeze({
+    provider_id: SPIN_PROVIDER_ID,
     provider_name: 'Spin',
     url: 'https://www.spin.app',
     mds_api_url: 'https://api.spin.pm/api/v1/mds'
   }),
   [WIND_PROVIDER_ID]: Object.freeze({
+    provider_id: WIND_PROVIDER_ID,
     provider_name: 'WIND',
     url: 'https://www.wind.co',
     mds_api_url: 'https://partners.wind.co/v1/mds'
   }),
   [TIER_PROVIDER_ID]: Object.freeze({
+    provider_id: TIER_PROVIDER_ID,
     provider_name: 'Tier',
     url: 'https://www.tier.app',
     mds_api_url: 'https://partner.tier-services.io/mds'
   }),
   [CLOUD_PROVIDER_ID]: Object.freeze({
+    provider_id: CLOUD_PROVIDER_ID,
     provider_name: 'Cloud',
     url: 'https://www.cloud.tt',
     mds_api_url: 'https://mds.cloud.tt',
     gbfs_api_url: 'https://mds.cloud.tt/gbfs'
   }),
   [BLUE_PROVIDER_ID]: Object.freeze({
+    provider_id: BLUE_PROVIDER_ID,
     provider_name: 'Blue',
     url: 'https://www.bluela.com',
     mds_api_url: 'https://api.bluela.com/mds/v0',
     gbfs_api_url: 'https://api.bluela.com/gbfs/v1/meta'
   }),
   [BOLT_PROVIDER_ID]: Object.freeze({
+    provider_id: BOLT_PROVIDER_ID,
     provider_name: 'Bolt',
     url: 'https://www.micromobility.com/',
     mds_api_url: 'https://bolt.miami/bolt2/api/mds'
   }),
   [CLEVR_PROVIDER_ID]: Object.freeze({
+    provider_id: CLEVR_PROVIDER_ID,
     provider_name: 'CLEVR',
     url: 'https://clevrmobility.com',
     mds_api_url: 'https://portal.clevrmobility.com/api/la/',
     gbfs_api_url: 'https://portal.clevrmobility.com/api/gbfs/en/discovery/'
   }),
   [SHERPA_PROVIDER_ID]: Object.freeze({
+    provider_id: SHERPA_PROVIDER_ID,
     provider_name: 'Sherpa',
     mds_api_url: 'https://mds.bird.co',
     gbfs_api_url: 'https://mds.bird.co/gbfs/platform-partner/sherpa-la'
   }),
   [OJO_PROVIDER_ID]: Object.freeze({
+    provider_id: OJO_PROVIDER_ID,
     provider_name: 'OjO Electric',
     url: 'https://www.ojoelectric.com',
     mds_api_url: 'https://api.ojoelectric.com/api/mds',
     gbfs_api_url: 'https://api.ojoelectric.com/api/mds/gbfs.json'
   }),
   [TEST1_PROVIDER_ID]: Object.freeze({
+    provider_id: TEST1_PROVIDER_ID,
     provider_name: 'Test 1'
   }),
   [TEST2_PROVIDER_ID]: Object.freeze({
+    provider_id: TEST2_PROVIDER_ID,
     provider_name: 'Test 2'
   }),
   [TEST3_PROVIDER_ID]: Object.freeze({
+    provider_id: TEST3_PROVIDER_ID,
     provider_name: 'Test 3'
   }),
   [TEST4_PROVIDER_ID]: Object.freeze({
+    provider_id: TEST4_PROVIDER_ID,
     provider_name: 'Test 4'
   })
 })

--- a/packages/mds-types/index.ts
+++ b/packages/mds-types/index.ts
@@ -372,6 +372,7 @@ export interface BBox {
 export type BoundingBox = [[number, number], [number, number]]
 
 export interface Provider {
+  provider_id: UUID
   provider_name: string
   url?: string
   mds_api_url?: string


### PR DESCRIPTION
It seems useful to have an endpoint that returns the canonical list of MDS providers. The northbound native API seems like a good placeholder. I think eventually, there will be database backing for this or it will be an endpoint maintained by the assigning authority for provider IDs assuming there is some desire for these to be managed globally unique identifiers.

Also, removed the hardcoding of `PATH_PREFIX` from code (unit tests) in favor of passing it in through npm scripts.

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [x] Native

