### PR TITLE
Change service_end provider event mapping

### DIFF
--- a/packages/mds-provider/tests/status-changes.spec.ts
+++ b/packages/mds-provider/tests/status-changes.spec.ts
@@ -24,7 +24,7 @@ const fixtures: {
   },
   {
     agency: { event_type: VEHICLE_EVENTS.service_end },
-    provider: { event_type: PROVIDER_EVENTS.removed, event_type_reason: PROVIDER_REASONS.service_end }
+    provider: { event_type: PROVIDER_EVENTS.unavailable, event_type_reason: PROVIDER_REASONS.maintenance }
   },
   {
     agency: { event_type: VEHICLE_EVENTS.service_end, event_type_reason: VEHICLE_REASONS.low_battery },
@@ -36,11 +36,11 @@ const fixtures: {
   },
   {
     agency: { event_type: VEHICLE_EVENTS.service_end, event_type_reason: VEHICLE_REASONS.compliance },
-    provider: { event_type: PROVIDER_EVENTS.removed, event_type_reason: PROVIDER_REASONS.service_end }
+    provider: { event_type: PROVIDER_EVENTS.unavailable, event_type_reason: PROVIDER_REASONS.maintenance }
   },
   {
     agency: { event_type: VEHICLE_EVENTS.service_end, event_type_reason: VEHICLE_REASONS.off_hours },
-    provider: { event_type: PROVIDER_EVENTS.removed, event_type_reason: PROVIDER_REASONS.service_end }
+    provider: { event_type: PROVIDER_EVENTS.unavailable, event_type_reason: PROVIDER_REASONS.maintenance }
   },
   {
     agency: { event_type: VEHICLE_EVENTS.provider_drop_off },

--- a/packages/mds-provider/utils.ts
+++ b/packages/mds-provider/utils.ts
@@ -33,8 +33,16 @@ const AgencyEventMap: {
       [VEHICLE_REASONS.low_battery]: {
         event_type: PROVIDER_EVENTS.unavailable,
         event_type_reason: PROVIDER_REASONS.low_battery
+      },
+      [VEHICLE_REASONS.maintenance]: {
+        event_type: PROVIDER_EVENTS.unavailable,
+        event_type_reason: PROVIDER_REASONS.maintenance
       }
     },
+    // There is a discrepancy between Agency and Provider with the definition of the service_end event.
+    // service_end transitions vehicles to the unavailable state in Agency while Provider considers them removed.
+    // The service_end mapping is being modified such that Provider more closely matches Agency and the resulting
+    // vehicle state is consistent.
     otherwise: {
       event_type: PROVIDER_EVENTS.unavailable,
       event_type_reason: PROVIDER_REASONS.maintenance

--- a/packages/mds-provider/utils.ts
+++ b/packages/mds-provider/utils.ts
@@ -33,15 +33,11 @@ const AgencyEventMap: {
       [VEHICLE_REASONS.low_battery]: {
         event_type: PROVIDER_EVENTS.unavailable,
         event_type_reason: PROVIDER_REASONS.low_battery
-      },
-      [VEHICLE_REASONS.maintenance]: {
-        event_type: PROVIDER_EVENTS.unavailable,
-        event_type_reason: PROVIDER_REASONS.maintenance
       }
     },
     otherwise: {
-      event_type: PROVIDER_EVENTS.removed,
-      event_type_reason: PROVIDER_REASONS.service_end
+      event_type: PROVIDER_EVENTS.unavailable,
+      event_type_reason: PROVIDER_REASONS.maintenance
     }
   },
   [VEHICLE_EVENTS.provider_drop_off]: {


### PR DESCRIPTION
The `Agency` to `Provider` mapping of the service_end event is being modified such that the resulting vehicle state is more consistent.

## Impacts
- [x] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance

