### PR TITLE
Add API Gateway authorizer lambda deploy scripts

### DIFF
--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
+    "lambda:ladot-production-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-production-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:ladot-sandbox-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"


### PR DESCRIPTION
An authorizer lambda is required for each access token audience. Create deploy scripts to update the lambda function code.
