### PR TITLE
Express middleware to verify access via scopes

### DIFF
--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -78,14 +78,11 @@ const MDS_ACCESS_SCOPES = ['admin:all', 'test:all'] as const
 type MDS_ACCESS_SCOPE = typeof MDS_ACCESS_SCOPES[number]
 
 export const HasAccessScope = (scopes: MDS_ACCESS_SCOPE[], claims: ApiAuthorizerClaims | null) => {
-  if (scopes.length === 0) {
-    return true
-  }
-  if (claims && claims.scope) {
+  if (scopes.length > 0 && claims && claims.scope) {
     const granted = claims.scope.split(' ')
     return scopes.some(scope => granted.includes(scope))
   }
-  return false
+  return scopes.length === 0
 }
 
 // This will generete an Express middleware function to verify that the token claims

--- a/packages/mds-api-server/index.ts
+++ b/packages/mds-api-server/index.ts
@@ -77,7 +77,7 @@ export const ApiServer = (
 const MDS_ACCESS_SCOPES = ['admin:all', 'test:all'] as const
 type MDS_ACCESS_SCOPE = typeof MDS_ACCESS_SCOPES[number]
 
-export const HasAccessScope = (scopes: MDS_ACCESS_SCOPE[], claims: ApiAuthorizerClaims | null) => {
+export const hasAccessScope = (scopes: MDS_ACCESS_SCOPE[], claims: ApiAuthorizerClaims | null) => {
   if (scopes.length > 0 && claims && claims.scope) {
     const granted = claims.scope.split(' ')
     return scopes.some(scope => granted.includes(scope))
@@ -87,15 +87,15 @@ export const HasAccessScope = (scopes: MDS_ACCESS_SCOPE[], claims: ApiAuthorizer
 
 // This will generete an Express middleware function to verify that the token claims
 // contain one or more of the specified scopes, for example:
-// VerifyAccessScope('test:all', 'admin:all') allows access with either test:all OR admin:all
+// verifyAccessScope('test:all', 'admin:all') allows access with either test:all OR admin:all
 // Express middleware can be chained to require more than one scope, for example:
-// VerifyAccessScope('test:all'), VerifyAccessScope('admin:all') requires both test:all AND admin:all
-export const VerifyAccessScope = (...scopes: MDS_ACCESS_SCOPE[]) => (
+// verifyAccessScope('test:all'), verifyAccessScope('admin:all') requires both test:all AND admin:all
+export const verifyAccessScope = (...scopes: MDS_ACCESS_SCOPE[]) => (
   req: ApiRequest,
   res: ApiResponse,
   next: express.NextFunction
 ) => {
-  if (HasAccessScope(scopes, res.locals.claims)) {
+  if (hasAccessScope(scopes, res.locals.claims)) {
     return next()
   }
   return res.status(403).send({ error: new AuthorizationError('no access without scope', { scopes }) })

--- a/packages/mds-api-server/tests/index.spec.ts
+++ b/packages/mds-api-server/tests/index.spec.ts
@@ -18,7 +18,7 @@
 
 import supertest from 'supertest'
 import test from 'unit.js'
-import { ApiServer, HasAccessScope } from '@mds-core/mds-api-server'
+import { ApiServer, hasAccessScope } from '@mds-core/mds-api-server'
 import { ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
 
 const request = supertest(ApiServer(app => app))
@@ -121,11 +121,11 @@ describe('Testing API Server', () => {
   })
 
   it('verifies scope access', done => {
-    test.value(HasAccessScope([], null)).is(true)
-    test.value(HasAccessScope(['admin:all'], null)).is(false)
-    test.value(HasAccessScope(['admin:all'], { scope: 'test:all' } as ApiAuthorizerClaims)).is(false)
+    test.value(hasAccessScope([], null)).is(true)
+    test.value(hasAccessScope(['admin:all'], null)).is(false)
+    test.value(hasAccessScope(['admin:all'], { scope: 'test:all' } as ApiAuthorizerClaims)).is(false)
     test
-      .value(HasAccessScope(['admin:all'], { scope: ['test:all', 'admin:all'].join(' ') } as ApiAuthorizerClaims))
+      .value(hasAccessScope(['admin:all'], { scope: ['test:all', 'admin:all'].join(' ') } as ApiAuthorizerClaims))
       .is(true)
     done()
   })

--- a/packages/mds-api-server/tests/index.spec.ts
+++ b/packages/mds-api-server/tests/index.spec.ts
@@ -18,7 +18,8 @@
 
 import supertest from 'supertest'
 import test from 'unit.js'
-import { ApiServer } from '@mds-core/mds-api-server'
+import { ApiServer, HasAccessScope } from '@mds-core/mds-api-server'
+import { ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
 
 const request = supertest(ApiServer(app => app))
 
@@ -117,5 +118,15 @@ describe('Testing API Server', () => {
       .end(err => {
         done(err)
       })
+  })
+
+  it('verifies scope access', done => {
+    test.value(HasAccessScope([], null)).is(true)
+    test.value(HasAccessScope(['admin:all'], null)).is(false)
+    test.value(HasAccessScope(['admin:all'], { scope: 'test:all' } as ApiAuthorizerClaims)).is(false)
+    test
+      .value(HasAccessScope(['admin:all'], { scope: ['test:all', 'admin:all'].join(' ') } as ApiAuthorizerClaims))
+      .is(true)
+    done()
   })
 })

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -43,7 +43,7 @@ import {
 import { providerName } from '@mds-core/mds-providers' // map of uuids -> obj
 import { AUDIT_EVENT_TYPES, AuditEvent, TelemetryData, Timestamp, Telemetry, AuditDetails } from '@mds-core/mds-types'
 import { asPagingParams, asJsonApiLinks } from '@mds-core/mds-api-helpers'
-import { VerifyAccessScope } from '@mds-core/mds-api-server'
+import { verifyAccessScope } from '@mds-core/mds-api-server'
 import {
   AuditApiAuditEndRequest,
   AuditApiAuditNoteRequest,
@@ -158,7 +158,7 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/test/initialize'),
-    VerifyAccessScope('test:all'),
+    verifyAccessScope('test:all'),
     async (req: AuditApiRequest, res: AuditApiResponse) => {
       try {
         const kind = await db.initialize()
@@ -176,7 +176,7 @@ function api(app: express.Express): express.Express {
 
   app.get(
     pathsFor('/test/shutdown'),
-    VerifyAccessScope('test:all'),
+    verifyAccessScope('test:all'),
     async (req: AuditApiRequest, res: AuditApiResponse) => {
       await db.shutdown()
       await cache.shutdown()

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -43,6 +43,7 @@ import {
 import { providerName } from '@mds-core/mds-providers' // map of uuids -> obj
 import { AUDIT_EVENT_TYPES, AuditEvent, TelemetryData, Timestamp, Telemetry, AuditDetails } from '@mds-core/mds-types'
 import { asPagingParams, asJsonApiLinks } from '@mds-core/mds-api-helpers'
+import { VerifyAccessScope } from '@mds-core/mds-api-server'
 import {
   AuditApiAuditEndRequest,
   AuditApiAuditNoteRequest,
@@ -107,19 +108,8 @@ function api(app: express.Express): express.Express {
       try {
         if (!req.path.includes('/health' || req.path === '/')) {
           // verify presence of subject_id
-          const { principalId, email, scope } = res.locals.claims
+          const { principalId, email } = res.locals.claims
           const subject_id = email || principalId
-
-          // no test access without auth
-          if (req.path.includes('/test/')) {
-            /* istanbul ignore if */
-            if (!scope || !scope.includes('test:all')) {
-              // 403 Forbidden
-              return res
-                .status(403)
-                .send({ error: new AuthorizationError('no test access without test:all scope', { scope }) })
-            }
-          }
 
           /* istanbul ignore if */
           if (!subject_id) {
@@ -166,29 +156,37 @@ function api(app: express.Express): express.Express {
 
   // ///////////////////// begin test-only endpoints ///////////////////////
 
-  app.get(pathsFor('/test/initialize'), async (req: AuditApiRequest, res: AuditApiResponse) => {
-    try {
-      const kind = await db.initialize()
-      const result = `Database initialized (${kind})`
-      await log.info(result)
-      // 200 OK
-      res.status(200).send({ result })
-    } catch (err) /* istanbul ignore next */ {
-      // 500 Internal Server Error
-      await log.error(`fail ${req.method} ${req.originalUrl}`, err.stack || JSON.stringify(err))
-      res.status(500).send({ error: new ServerError(err) })
+  app.get(
+    pathsFor('/test/initialize'),
+    VerifyAccessScope('test:all'),
+    async (req: AuditApiRequest, res: AuditApiResponse) => {
+      try {
+        const kind = await db.initialize()
+        const result = `Database initialized (${kind})`
+        await log.info(result)
+        // 200 OK
+        res.status(200).send({ result })
+      } catch (err) /* istanbul ignore next */ {
+        // 500 Internal Server Error
+        await log.error(`fail ${req.method} ${req.originalUrl}`, err.stack || JSON.stringify(err))
+        res.status(500).send({ error: new ServerError(err) })
+      }
     }
-  })
+  )
 
-  app.get(pathsFor('/test/shutdown'), async (req: AuditApiRequest, res: AuditApiResponse) => {
-    await db.shutdown()
-    await cache.shutdown()
-    await log.info('shutdown complete (in theory)')
-    // 200 OK
-    res.status(200).send({
-      result: 'db shutdown'
-    })
-  })
+  app.get(
+    pathsFor('/test/shutdown'),
+    VerifyAccessScope('test:all'),
+    async (req: AuditApiRequest, res: AuditApiResponse) => {
+      await db.shutdown()
+      await cache.shutdown()
+      await log.info('shutdown complete (in theory)')
+      // 200 OK
+      res.status(200).send({
+        result: 'db shutdown'
+      })
+    }
+  )
   // ///////////////////// end test-only endpoints ///////////////////////
 
   // /////////////////// begin audit-only endpoints //////////////////////


### PR DESCRIPTION
Added a new middleware function that can be used to restrict access to endpoints by scope. Also, showed an example of how this is used.

