### PR TITLE
[mds-audit] Get authenticated user's email from a custom claim

### DIFF
--- a/aws-lambda/api-gateway-authorizer/index.ts
+++ b/aws-lambda/api-gateway-authorizer/index.ts
@@ -8,7 +8,7 @@ import { ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
 // These environment variables MUST be set
 const {
   TOKEN_PUBLIC_KEY = '', // X.509 Certificate for verifying signature
-  TOKEN_AUDIENCE = '', // Space delimited list of audiences
+  TOKEN_AUDIENCES = '', // Space delimited list of audiences
   TOKEN_ISSUER = '', // Token issuer
   TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id', // Custom provider_id claim in access token
   TOKEN_USER_EMAIL_CLAIM = 'https://ladot.io/user_email' // Custom user_email claim in access token
@@ -51,7 +51,7 @@ export const handler: Handler<
     if (scheme.toLowerCase() === 'bearer' && token) {
       try {
         const decoded = verify(token, TOKEN_PUBLIC_KEY.split('\\n').join('\n'), {
-          audience: TOKEN_AUDIENCE.split(' '),
+          audience: TOKEN_AUDIENCES.split(' '),
           issuer: TOKEN_ISSUER
         })
         if (typeof decoded === 'object') {

--- a/aws-lambda/api-gateway-authorizer/index.ts
+++ b/aws-lambda/api-gateway-authorizer/index.ts
@@ -58,8 +58,8 @@ export const handler: Handler<
           const {
             sub: principalId,
             scope,
-            [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
-            [TOKEN_USER_EMAIL_CLAIM]: user_email
+            [TOKEN_PROVIDER_ID_CLAIM]: provider_id = null,
+            [TOKEN_USER_EMAIL_CLAIM]: user_email = null
           } = decoded as JWT
           console.log('Authorization Succeeded:', event.methodArn, principalId)
           callback(null, generatePolicy(principalId, { provider_id, scope, user_email }))

--- a/aws-lambda/api-gateway-authorizer/index.ts
+++ b/aws-lambda/api-gateway-authorizer/index.ts
@@ -59,11 +59,10 @@ export const handler: Handler<
             sub: principalId,
             scope,
             [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
-            [TOKEN_USER_EMAIL_CLAIM]: user_email,
-            email // Support getting email from previously issued id_tokens
+            [TOKEN_USER_EMAIL_CLAIM]: user_email
           } = decoded as JWT
           console.log('Authorization Succeeded:', event.methodArn, principalId)
-          callback(null, generatePolicy(principalId, { provider_id, scope, user_email: user_email || email }))
+          callback(null, generatePolicy(principalId, { provider_id, scope, user_email }))
           return
         }
       } catch (err) {

--- a/aws-lambda/api-gateway-authorizer/index.ts
+++ b/aws-lambda/api-gateway-authorizer/index.ts
@@ -9,7 +9,7 @@ import { ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
 const {
   AUTH0_PUBLIC_KEY = '', // X.509 Certificate from Auth0 for verifying JWT signature
   TOKEN_AUDIENCES = '', // Space delimited list of valid token audience (aud) values
-  TOKEN_ISSUER = '', // Valid token issuer (iss) value
+  TOKEN_ISSUERS = '', // Space delimited list of valid token issuer (iss) values
   TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id', // Custom provider_id claim in access token
   TOKEN_USER_EMAIL_CLAIM = 'https://ladot.io/user_email' // Custom user_email claim in access token
 } = process.env
@@ -52,7 +52,7 @@ export const handler: Handler<
       try {
         const decoded = verify(token, AUTH0_PUBLIC_KEY.split('\\n').join('\n'), {
           audience: TOKEN_AUDIENCES.split(' '),
-          issuer: TOKEN_ISSUER
+          issuer: TOKEN_ISSUERS.split(' ')
         })
         if (typeof decoded === 'object') {
           const {

--- a/aws-lambda/api-gateway-authorizer/index.ts
+++ b/aws-lambda/api-gateway-authorizer/index.ts
@@ -9,7 +9,8 @@ const {
   AUTH0_CLIENT_PUBLIC_KEY = '',
   AUTH0_API_IDENTIFIER = '',
   TOKEN_ISSUER = '',
-  TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id'
+  TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id',
+  TOKEN_USER_EMAIL_CLAIM = 'https://ladot.io/user_email'
 } = process.env
 
 type AuthResponseContext = Required<Omit<ApiAuthorizerClaims, 'principalId'>>
@@ -53,9 +54,14 @@ export const handler: Handler<
           issuer: TOKEN_ISSUER
         })
         if (typeof decoded === 'object') {
-          const { sub: principalId, scope, [TOKEN_PROVIDER_ID_CLAIM]: provider_id, email } = decoded as JWT
+          const {
+            sub: principalId,
+            scope,
+            [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
+            [TOKEN_USER_EMAIL_CLAIM]: user_email
+          } = decoded as JWT
           console.log('Authorization Succeeded:', event.methodArn, principalId)
-          callback(null, generatePolicy(principalId, { provider_id, scope, email }))
+          callback(null, generatePolicy(principalId, { provider_id, scope, user_email }))
           return
         }
       } catch (err) {

--- a/aws-lambda/api-gateway-authorizer/index.ts
+++ b/aws-lambda/api-gateway-authorizer/index.ts
@@ -7,9 +7,9 @@ import { ApiAuthorizerClaims } from '@mds-core/mds-api-authorizer'
 
 // These environment variables MUST be set
 const {
-  TOKEN_PUBLIC_KEY = '', // X.509 Certificate for verifying signature
-  TOKEN_AUDIENCES = '', // Space delimited list of audiences
-  TOKEN_ISSUER = '', // Token issuer
+  AUTH0_PUBLIC_KEY = '', // X.509 Certificate from Auth0 for verifying JWT signature
+  TOKEN_AUDIENCES = '', // Space delimited list of valid token audience (aud) values
+  TOKEN_ISSUER = '', // Valid token issuer (iss) value
   TOKEN_PROVIDER_ID_CLAIM = 'https://ladot.io/provider_id', // Custom provider_id claim in access token
   TOKEN_USER_EMAIL_CLAIM = 'https://ladot.io/user_email' // Custom user_email claim in access token
 } = process.env
@@ -50,7 +50,7 @@ export const handler: Handler<
     const [scheme, token] = event.authorizationToken.split(' ')
     if (scheme.toLowerCase() === 'bearer' && token) {
       try {
-        const decoded = verify(token, TOKEN_PUBLIC_KEY.split('\\n').join('\n'), {
+        const decoded = verify(token, AUTH0_PUBLIC_KEY.split('\\n').join('\n'), {
           audience: TOKEN_AUDIENCES.split(' '),
           issuer: TOKEN_ISSUER
         })

--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -12,7 +12,7 @@
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:ladot-production-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-production-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "lambda:ladot-sandbox-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
-    "lambda:develop-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name lacuna-auth0-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:develop-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name develop-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"

--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -12,8 +12,7 @@
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:ladot-production-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-production-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "lambda:ladot-sandbox-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
-    "lambda:ladot-prod-mds-audit-auth": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-audit-auth --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
-    "lambda:ladot-sandbox-mds-audit-auth": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-audit-auth --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:auth0-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name lacuna-auth0-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"

--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -12,7 +12,7 @@
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:ladot-production-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-production-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "lambda:ladot-sandbox-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
-    "lambda:auth0-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name lacuna-auth0-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:develop-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name lacuna-auth0-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"

--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -12,6 +12,8 @@
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
     "lambda:ladot-production-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-production-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "lambda:ladot-sandbox-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:ladot-prod-mds-audit-auth": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-audit-auth --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:ladot-sandbox-mds-audit-auth": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-audit-auth --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"

--- a/aws-lambda/api-gateway-authorizer/package.json
+++ b/aws-lambda/api-gateway-authorizer/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "lambda:ladot-production-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-production-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
+    "lambda:ladot-prod-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-prod-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "lambda:ladot-sandbox-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-west-2 --function-name ladot-sandbox-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "lambda:develop-mds-api-gateway-authorizer": "yarn bundle && aws lambda update-function-code --region us-east-2 --function-name develop-mds-api-gateway-authorizer --zip-file fileb://dist/bundles/api-gateway-authorizer.zip",
     "test": "yarn test:eslint && yarn test:unit",

--- a/container-images/env-inject/tsconfig.build.json
+++ b/container-images/env-inject/tsconfig.build.json
@@ -3,7 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "references": [
-    { "path": "../../packages/mds-api-server/tsconfig.build.json" }
-  ]
+  "references": []
 }

--- a/packages/mds-api-authorizer/index.ts
+++ b/packages/mds-api-authorizer/index.ts
@@ -26,10 +26,9 @@ export const AuthorizationHeaderApiAuthorizer: ApiAuthorizer = req => {
           scope,
           [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
           [TOKEN_USER_EMAIL_CLAIM]: user_email,
-          email,
           ...claims
         } = decode(token)
-        return { principalId, scope, provider_id, user_email: user_email || email, ...claims }
+        return { principalId, scope, provider_id, user_email, ...claims }
       },
       basic: () => {
         const [principalId, scope] = Buffer.from(token, 'base64')

--- a/packages/mds-api-authorizer/index.ts
+++ b/packages/mds-api-authorizer/index.ts
@@ -26,9 +26,10 @@ export const AuthorizationHeaderApiAuthorizer: ApiAuthorizer = req => {
             scope,
             [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
             [TOKEN_USER_EMAIL_CLAIM]: user_email,
+            email,
             ...claims
           } = jwtDecode(token)
-          return { principalId, scope, provider_id, user_email, ...claims }
+          return { principalId, scope, provider_id, user_email: user_email || email, ...claims }
         },
         basic: () => {
           const [principalId, scope] = Buffer.from(token, 'base64')

--- a/packages/mds-api-authorizer/index.ts
+++ b/packages/mds-api-authorizer/index.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import jwtDecode from 'jwt-decode'
+import decode from 'jwt-decode'
 import { UUID } from '@mds-core/mds-types'
 
 export interface ApiAuthorizerClaims {
@@ -18,30 +18,28 @@ export type ApiAuthorizer = (req: express.Request) => ApiAuthorizerClaims | null
 
 export const AuthorizationHeaderApiAuthorizer: ApiAuthorizer = req => {
   if (req.headers && req.headers.authorization) {
-    const decode = ([scheme, token]: string[]): ApiAuthorizerClaims | null => {
-      const decoders: { [scheme: string]: () => ApiAuthorizerClaims } = {
-        bearer: () => {
-          const {
-            sub: principalId,
-            scope,
-            [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
-            [TOKEN_USER_EMAIL_CLAIM]: user_email,
-            email,
-            ...claims
-          } = jwtDecode(token)
-          return { principalId, scope, provider_id, user_email: user_email || email, ...claims }
-        },
-        basic: () => {
-          const [principalId, scope] = Buffer.from(token, 'base64')
-            .toString()
-            .split('|')
-          return { principalId, scope, provider_id: principalId, user_email: null }
-        }
+    const [scheme, token] = req.headers.authorization.split(' ')
+    const decoders: { [scheme: string]: () => ApiAuthorizerClaims } = {
+      bearer: () => {
+        const {
+          sub: principalId,
+          scope,
+          [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
+          [TOKEN_USER_EMAIL_CLAIM]: user_email,
+          email,
+          ...claims
+        } = decode(token)
+        return { principalId, scope, provider_id, user_email: user_email || email, ...claims }
+      },
+      basic: () => {
+        const [principalId, scope] = Buffer.from(token, 'base64')
+          .toString()
+          .split('|')
+        return { principalId, scope, provider_id: principalId, user_email: null }
       }
-      const decoder = decoders[scheme.toLowerCase()]
-      return decoder ? decoder() : null
     }
-    return decode(req.headers.authorization.split(' '))
+    const decoder = decoders[scheme.toLowerCase()]
+    return decoder ? decoder() : null
   }
   return null
 }

--- a/packages/mds-api-authorizer/index.ts
+++ b/packages/mds-api-authorizer/index.ts
@@ -5,7 +5,7 @@ import { UUID } from '@mds-core/mds-types'
 export interface ApiAuthorizerClaims {
   principalId: string
   scope: string
-  provider_id: UUID
+  provider_id: UUID | null
   user_email: string | null
 }
 
@@ -24,8 +24,8 @@ export const AuthorizationHeaderApiAuthorizer: ApiAuthorizer = req => {
         const {
           sub: principalId,
           scope,
-          [TOKEN_PROVIDER_ID_CLAIM]: provider_id,
-          [TOKEN_USER_EMAIL_CLAIM]: user_email,
+          [TOKEN_PROVIDER_ID_CLAIM]: provider_id = null,
+          [TOKEN_USER_EMAIL_CLAIM]: user_email = null,
           ...claims
         } = decode(token)
         return { principalId, scope, provider_id, user_email, ...claims }

--- a/packages/mds-audit/api.ts
+++ b/packages/mds-audit/api.ts
@@ -108,8 +108,8 @@ function api(app: express.Express): express.Express {
       try {
         if (!req.path.includes('/health' || req.path === '/')) {
           // verify presence of subject_id
-          const { principalId, email } = res.locals.claims
-          const subject_id = email || principalId
+          const { principalId, user_email } = res.locals.claims
+          const subject_id = user_email || principalId
 
           /* istanbul ignore if */
           if (!subject_id) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@aws-lambda/*": ["aws-lambda/*/index.ts"],
+      "@container-images/*": ["container-images/*/index.ts"],
       "@mds-core/*": ["packages/*/index.ts"],
       "*": ["@types/*", "*"]
     }


### PR DESCRIPTION
These are the changes required to extract a user's email from an API access token custom claim and also to support multiple valid audiences. The changes should be backwards compatible with existing Auth0 APIs, M2M tokens, and other application tokens. The plan is to deploy these changes to a new authorizer lambda and repoint API Gateway in addition to creating new scoped Auth0 APIs. Then we can request applications to switch to using the API audience for the new scoped APIs and switch Compliance Mobile to use API access tokens rather than ID tokens for accessing the API.


## Impacts
- [ ] Provider
- [ ] Agency
- [x] Audit
- [ ] Policy
- [ ] Compliance

