### PR TITLE
[mds-agency] No access without valid provider ID

### DIFF
--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -86,19 +86,17 @@ function api(app: express.Express): express.Express {
             }
           }
 
-          if (provider_id) {
-            if (!isUUID(provider_id)) {
-              await log.warn(req.originalUrl, 'invalid provider_id is not a UUID', provider_id)
-              return res.status(400).send({
-                result: `invalid provider_id ${provider_id} is not a UUID`
-              })
-            }
+          if (!isUUID(provider_id)) {
+            await log.warn(req.originalUrl, 'invalid provider_id is not a UUID', provider_id)
+            return res.status(400).send({
+              result: `invalid provider_id ${provider_id} is not a UUID`
+            })
+          }
 
-            if (!isProviderId(provider_id)) {
-              return res.status(400).send({
-                result: `invalid provider_id ${provider_id} is not a known provider`
-              })
-            }
+          if (!isProviderId(provider_id)) {
+            return res.status(400).send({
+              result: `invalid provider_id ${provider_id} is not a known provider`
+            })
           }
 
           // stash provider_id


### PR DESCRIPTION
Agency should require a provider_id. There was an extraneous if condition that would allow access to agency endpoints without a valid provider_id. A recent change to our authorizers brought this issue to light. TypeScript FTW.

## Impacts
- [ ] Provider
- [x] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance

