### PR TITLE
Convert numeric query string parameters before type guarding

### DIFF
--- a/packages/mds-native/api.ts
+++ b/packages/mds-native/api.ts
@@ -84,17 +84,14 @@ function api(app: express.Express): express.Express {
       params: { cursor },
       query: { limit: query_limit, ...filters }
     } = req
-    const limit = numericQueryStringParam(query_limit)
+    const limit = numericQueryStringParam(query_limit) || 1000
     isValidNumber(limit, { required: false, min: 1, max: 1000, property: 'limit' })
     if (cursor) {
       if (Object.keys(filters).length > 0) {
         throw new ValidationError('unexpected_filters', { cursor, filters })
       }
       try {
-        return {
-          cursor: JSON.parse(Buffer.from(cursor, 'base64').toString('ascii')),
-          limit: Number(limit)
-        }
+        return { cursor: JSON.parse(Buffer.from(cursor, 'base64').toString('ascii')), limit }
       } catch (err) {
         throw new ValidationError('invalid_cursor', { cursor })
       }
@@ -106,7 +103,7 @@ function api(app: express.Express): express.Express {
       isValidDeviceId(device_id, { required: false })
       isValidTimestamp(start_time, { required: false })
       isValidTimestamp(end_time, { required: false })
-      return { cursor: { provider_id, device_id, start_time, end_time }, limit: Number(limit) }
+      return { cursor: { provider_id, device_id, start_time, end_time }, limit }
     }
   }
 

--- a/packages/mds-native/api.ts
+++ b/packages/mds-native/api.ts
@@ -96,7 +96,9 @@ function api(app: express.Express): express.Express {
         throw new ValidationError('invalid_cursor', { cursor })
       }
     } else {
-      const { provider_id, device_id, start_time, end_time } = filters
+      const { provider_id, device_id,  start_time: queried_start_time, end_time: queried_end_time } = filters
+      const start_time = queried_start_time ? Number(queried_start_time) : queried_start_time
+      const end_time = queried_end_time ? Number(queried_end_time) : queried_end_time
       isValidProviderId(provider_id, { required: false })
       isValidDeviceId(device_id, { required: false })
       isValidTimestamp(start_time, { required: false })

--- a/packages/mds-utils/tests/validators.spec.ts
+++ b/packages/mds-utils/tests/validators.spec.ts
@@ -74,6 +74,7 @@ describe('Tests validators', () => {
     test.assert.throws(() => isValidTimestamp(null), ValidationError)
     test.assert.throws(() => isValidTimestamp(1), ValidationError)
     test.value(isValidTimestamp('123', { assert: false })).is(false)
+    test.value(isValidTimestamp('1567695019935', { assert: false })).is(false)
     test.value(isValidTimestamp(Date.now())).is(true)
     done()
   })
@@ -137,24 +138,26 @@ describe('Tests validators', () => {
     test.assert.throws(() => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 200 } }), ValidationError)
     test.assert.throws(() => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: -200 } }), ValidationError)
     test.value(isValidTelemetry({ gps: { lat: 0, lng: 0 } }, { assert: false })).is(false)
+    test.assert.throws(() => isValidTelemetry({ timestamp: Date.now(), gps: { lat: '0', lng: 0 } }), ValidationError)
+    test.assert.throws(() => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: '0' } }), ValidationError)
     test.assert.throws(
-      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, speed: 'S' } }),
+      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, speed: '0' } }),
       ValidationError
     )
     test.assert.throws(
-      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, heading: 'H' } }),
+      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, heading: '0' } }),
       ValidationError
     )
     test.assert.throws(
-      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, accuracy: 'A' } }),
+      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, accuracy: '0' } }),
       ValidationError
     )
     test.assert.throws(
-      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, altitude: 'A' } }),
+      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0, altitude: '0' } }),
       ValidationError
     )
     test.assert.throws(
-      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0 }, charge: 'C' }),
+      () => isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0 }, charge: '0' }),
       ValidationError
     )
     test.value(isValidTelemetry({ timestamp: Date.now(), gps: { lat: 0, lng: 0 } })).is(true)

--- a/packages/mds-utils/validators.ts
+++ b/packages/mds-utils/validators.ts
@@ -41,11 +41,12 @@ interface ValidatorOptions {
 // Convert empty string to undefined so required/optional works as expected
 const stringSchema = Joi.string().empty('')
 
+// Don't allow type conversion
+const numberSchema = Joi.number().options({ convert: false })
+
 const uuidSchema = stringSchema.guid()
 
-const timestampSchema = Joi.number()
-  .options({ convert: false })
-  .min(1420099200000)
+const timestampSchema = numberSchema.min(1420099200000)
 
 const providerIdSchema = uuidSchema.valid(Object.keys(providers))
 
@@ -54,21 +55,21 @@ const vehicleIdSchema = stringSchema.max(255)
 const telemetrySchema = Joi.object().keys({
   gps: Joi.object()
     .keys({
-      lat: Joi.number()
+      lat: numberSchema
         .min(-90)
         .max(90)
         .required(),
-      lng: Joi.number()
+      lng: numberSchema
         .min(-180)
         .max(180)
         .required(),
-      speed: Joi.number().optional(),
-      heading: Joi.number().optional(),
-      accuracy: Joi.number().optional(),
-      altitude: Joi.number().optional()
+      speed: numberSchema.optional(),
+      heading: numberSchema.optional(),
+      accuracy: numberSchema.optional(),
+      altitude: numberSchema.optional()
     })
     .required(),
-  charge: Joi.number().optional(),
+  charge: numberSchema.optional(),
   provider_id: providerIdSchema.optional(),
   device_id: uuidSchema.optional(),
   timestamp: timestampSchema.required()
@@ -109,7 +110,7 @@ interface NumberValidatorOptions extends ValidatorOptions {
 export const isValidNumber = (value: unknown, options: Partial<NumberValidatorOptions> = {}): value is number =>
   Validate(
     value,
-    Joi.number()
+    numberSchema
       .min(options.min === undefined ? Number.MIN_SAFE_INTEGER : options.min)
       .max(options.max === undefined ? Number.MAX_SAFE_INTEGER : options.max),
     options


### PR DESCRIPTION
Treating strings as numbers can lead to unpredictable results. 

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [X] Native
- [ ] Policy Author


