### PR TITLE
[mds-metrics-sheet] Adds optional type to metrics event_counts_last_24h

### DIFF
--- a/packages/mds-metrics-sheet/metrics-log.ts
+++ b/packages/mds-metrics-sheet/metrics-log.ts
@@ -18,7 +18,6 @@ import GoogleSpreadsheet from 'google-spreadsheet'
 
 import { promisify } from 'util'
 import requestPromise from 'request-promise'
-import { get } from 'lodash'
 import log from '@mds-core/mds-logger'
 import {
   JUMP_PROVIDER_ID,
@@ -133,7 +132,7 @@ async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
         const dateOptions = { timeZone: 'America/Los_Angeles', day: '2-digit', month: '2-digit', year: 'numeric' }
         const timeOptions = { timeZone: 'America/Los_Angeles', hour12: false, hour: '2-digit', minute: '2-digit' }
         const d = new Date()
-        let [starts, ends, start_sla, end_sla, telems, telem_sla] = [0, 0, 0, 0, 0, 0]
+        let [enters, leaves, starts, ends, start_sla, end_sla, telems, telem_sla] = [0, 0, 0, 0, 0, 0, 0, 0]
         let event_counts = { service_start: 0, provider_drop_off: 0, trip_start: 0, trip_end: 0 }
         let status_counts = {
           available: 0,
@@ -150,6 +149,8 @@ async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
           status_counts = eventCountsToStatusCounts(event_counts_last_24h)
           starts = event_counts_last_24h.trip_start || 0
           ends = event_counts_last_24h.trip_end || 0
+          enters = event_counts_last_24h.trip_enter || 0
+          leaves = event_counts_last_24h.trip_leave || 0
           telems = last[provider.provider_id].telemetry_counts_last_24h || 0
           telem_sla = telems ? percent(last[provider.provider_id].late_telemetry_counts_last_24h, telems) : 0
           start_sla = starts ? percent(last[provider.provider_id].late_event_counts_last_24h.trip_start, starts) : 0
@@ -172,8 +173,8 @@ async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
           providerdropoff: event_counts.provider_drop_off || 0,
           tripstart: starts,
           tripend: ends,
-          tripenter: get(event_counts_last_24h, 'trip_enter', 0),
-          tripleave: get(event_counts_last_24h, 'trip_leave', 0),
+          tripenter: enters,
+          tripleave: leaves,
           telemetry: telems,
           telemetrysla: telem_sla,
           tripstartsla: start_sla,

--- a/packages/mds-metrics-sheet/metrics-log.ts
+++ b/packages/mds-metrics-sheet/metrics-log.ts
@@ -18,6 +18,7 @@ import GoogleSpreadsheet from 'google-spreadsheet'
 
 import { promisify } from 'util'
 import requestPromise from 'request-promise'
+import { get } from 'lodash'
 import log from '@mds-core/mds-logger'
 import {
   JUMP_PROVIDER_ID,
@@ -143,11 +144,12 @@ async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
           inactive: 0,
           elsewhere: 0
         }
-        if (last[provider.provider_id].event_counts_last_24h) {
-          event_counts = last[provider.provider_id].event_counts_last_24h
-          status_counts = eventCountsToStatusCounts(last[provider.provider_id].event_counts_last_24h)
-          starts = last[provider.provider_id].event_counts_last_24h.trip_start || 0
-          ends = last[provider.provider_id].event_counts_last_24h.trip_end || 0
+        const { event_counts_last_24h } = last[provider.provider_id]
+        if (event_counts_last_24h) {
+          event_counts = event_counts_last_24h
+          status_counts = eventCountsToStatusCounts(event_counts_last_24h)
+          starts = event_counts_last_24h.trip_start || 0
+          ends = event_counts_last_24h.trip_end || 0
           telems = last[provider.provider_id].telemetry_counts_last_24h || 0
           telem_sla = telems ? percent(last[provider.provider_id].late_telemetry_counts_last_24h, telems) : 0
           start_sla = starts ? percent(last[provider.provider_id].late_event_counts_last_24h.trip_start, starts) : 0
@@ -170,8 +172,8 @@ async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
           providerdropoff: event_counts.provider_drop_off || 0,
           tripstart: starts,
           tripend: ends,
-          tripenter: last[provider.provider_id].event_counts_last_24h.trip_enter || 0,
-          tripleave: last[provider.provider_id].event_counts_last_24h.trip_leave || 0,
+          tripenter: get(event_counts_last_24h, 'trip_enter', 0),
+          tripleave: get(event_counts_last_24h, 'trip_leave', 0),
           telemetry: telems,
           telemetrysla: telem_sla,
           tripstartsla: start_sla,

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -19,9 +19,7 @@
     "@mds-core/mds-logger": "0.1.9",
     "@mds-core/mds-providers": "0.1.9",
     "@mds-core/mds-types": "0.1.6",
-    "@types/lodash": "4.14.138",
     "google-spreadsheet": "2.0.8",
-    "lodash": "4.17.15",
     "request": "2.88.0",
     "request-promise": "4.2.4"
   }

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -19,7 +19,9 @@
     "@mds-core/mds-logger": "0.1.9",
     "@mds-core/mds-providers": "0.1.9",
     "@mds-core/mds-types": "0.1.6",
+    "@types/lodash": "4.14.138",
     "google-spreadsheet": "2.0.8",
+    "lodash": "4.17.15",
     "request": "2.88.0",
     "request-promise": "4.2.4"
   }

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
   },
   "author": "City of Los Angeles",
   "license": "Apache-2.0",

--- a/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
+++ b/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
@@ -1,0 +1,50 @@
+import uuid from 'uuid'
+import { mapProviderToPayload } from '../metrics-log'
+import { VehicleCountRow, LastDayStatsResponse } from '../types'
+
+const getStatus = (): VehicleCountRow['status'] => {
+  return {
+    available: 42,
+    reserved: 20,
+    unavailable: 5,
+    removed: 0,
+    inactive: 3,
+    trip: 5,
+    elsewhere: 17
+  }
+}
+
+const getEvent = (): VehicleCountRow['event_type'] => {
+  return {
+    // TODO type out these fields
+  } as VehicleCountRow['event_type']
+}
+
+const getLastDayStatsResponse = (): LastDayStatsResponse => {
+  return {
+    // TODO type out
+  } as LastDayStatsResponse
+}
+
+const getProvider = (): VehicleCountRow => {
+  return {
+    provider_id: uuid(),
+    provider: 'fake-provider',
+    count: 42,
+    status: getStatus(),
+    event_type: getEvent(),
+    areas: {},
+    areas_48h: {}
+  }
+}
+
+describe('MDS Metrics Sheet', () => {
+  describe('Metrics Log', () => {
+    it('Maps a provider to the correct payload', () => {
+      const provider = getProvider()
+      const lastDayStatsResponse = getLastDayStatsResponse()
+      const result = mapProviderToPayload(provider, lastDayStatsResponse)
+      console.log({ result })
+    })
+  })
+})

--- a/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
+++ b/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import uuid from 'uuid'
 import { mapProviderToPayload } from '../metrics-log'
 import { VehicleCountRow, LastDayStatsResponse } from '../types'
@@ -20,9 +21,19 @@ const getEvent = (): VehicleCountRow['event_type'] => {
   } as VehicleCountRow['event_type']
 }
 
-const getLastDayStatsResponse = (): LastDayStatsResponse => {
+const getLastDayStatsResponse = (provider_id: string): LastDayStatsResponse => {
   return {
     // TODO type out
+    [provider_id]: {
+      trips_last_24h: 1,
+      ms_since_last_event: 5582050,
+      late_event_counts_last_24h: {},
+      telemetry_counts_last_24h: 5,
+      late_telemetry_counts_last_24h: 1,
+      events_last_24h: 3,
+      events_not_in_conformance: 1,
+      name: 'fake-name'
+    }
   } as LastDayStatsResponse
 }
 
@@ -38,13 +49,42 @@ const getProvider = (): VehicleCountRow => {
   }
 }
 
+const getExpectedPayload = (date: string) => {
+  return {
+    date,
+    name: 'fake-provider',
+    registered: 42,
+    deployed: 72,
+    validtrips: 'tbd',
+    trips: 1,
+    servicestart: 0,
+    providerdropoff: 0,
+    tripstart: 0,
+    tripend: 0,
+    tripenter: 0,
+    tripleave: 0,
+    telemetry: 0,
+    telemetrysla: 0,
+    tripstartsla: 0,
+    tripendsla: 0,
+    available: 0,
+    unavailable: 0,
+    reserved: 0,
+    trip: 0,
+    removed: 0,
+    inactive: 0,
+    elsewhere: 0
+  }
+}
+
 describe('MDS Metrics Sheet', () => {
   describe('Metrics Log', () => {
     it('Maps a provider to the correct payload', () => {
       const provider = getProvider()
-      const lastDayStatsResponse = getLastDayStatsResponse()
+      const lastDayStatsResponse = getLastDayStatsResponse(provider.provider_id)
       const result = mapProviderToPayload(provider, lastDayStatsResponse)
-      console.log({ result })
+      const expected = getExpectedPayload(result.date)
+      assert.deepStrictEqual(result, expected)
     })
   })
 })

--- a/packages/mds-metrics-sheet/types.ts
+++ b/packages/mds-metrics-sheet/types.ts
@@ -1,6 +1,6 @@
 import { UUID, VEHICLE_STATUS, VEHICLE_EVENT } from '@mds-core/mds-types'
 
-interface VehicleCountRow {
+export interface VehicleCountRow {
   provider_id: UUID
   provider: string
   count: number

--- a/packages/mds-metrics-sheet/types.ts
+++ b/packages/mds-metrics-sheet/types.ts
@@ -16,7 +16,7 @@ export interface LastDayStatsResponse {
   [s: string]: {
     trips_last_24h: number
     ms_since_last_event: 5582050
-    event_counts_last_24h: { [s in VEHICLE_EVENT]: number }
+    event_counts_last_24h?: { [s in VEHICLE_EVENT]: number }
     late_event_counts_last_24h: { [s in VEHICLE_EVENT]: number }
     telemetry_counts_last_24h: number
     late_telemetry_counts_last_24h: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,6 +578,11 @@
   resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
   integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
 
+"@types/lodash@4.14.138":
+  version "4.14.138"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
+  integrity sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==
+
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -4246,7 +4251,7 @@ lodash.unescape@4.0.1:
   dependencies:
     lodash._createwrapper "^3.0.0"
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,11 +578,6 @@
   resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
   integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
 
-"@types/lodash@4.14.138":
-  version "4.14.138"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
-  integrity sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==
-
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -4251,7 +4246,7 @@ lodash.unescape@4.0.1:
   dependencies:
     lodash._createwrapper "^3.0.0"
 
-lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
This should squash this lambda log error:

2019-09-18T07:00:45.559Z    0c7fca82-d644-4985-8b37-15cbcd440f5e    ERROR    ERROR getProviderMetrics TypeError: Cannot read property 'trip_enter' of undefined

Testing plan:
1. Run test suite

Fixes MDSAAS-158

## PR Checklist

 - [ X] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ X] briefly describe the changes in this PR
 - [X ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author

Not sure what this touches. Let me know if you have any suggestions for adding to the test suite.