### PR TITLE
[mds-metrics-sheet] Adds optional type to metrics event_counts_last_24h

### DIFF
--- a/packages/mds-metrics-sheet/metrics-log.ts
+++ b/packages/mds-metrics-sheet/metrics-log.ts
@@ -30,7 +30,7 @@ import {
   BOLT_PROVIDER_ID
 } from '@mds-core/mds-providers'
 import { VEHICLE_EVENT, EVENT_STATUS_MAP, VEHICLE_STATUS } from '@mds-core/mds-types'
-import { VehicleCountResponse, LastDayStatsResponse, MetricsSheetRow } from './types'
+import { VehicleCountResponse, LastDayStatsResponse, MetricsSheetRow, VehicleCountRow } from './types'
 
 // The list of providers ids on which to report
 const reportProviders = [
@@ -58,21 +58,6 @@ function percent(a: number, total: number) {
   return Math.round(((total - a) / total) * 10000) / 10000
 }
 
-async function appendSheet(sheetName: string, rows: MetricsSheetRow[]) {
-  const doc = new GoogleSpreadsheet(process.env.SPREADSHEET_ID)
-  await promisify(doc.useServiceAccountAuth)(creds)
-  const info = await promisify(doc.getInfo)()
-  log.info(`Loaded doc: ${info.title} by ${info.author.email}`)
-  const sheet = info.worksheets.filter((s: { title: string; rowCount: number } & unknown) => s.title === sheetName)[0]
-  log.info(`${sheetName} sheet: ${sheet.title} ${sheet.rowCount}x${sheet.colCount}`)
-  if (sheet.title === sheetName) {
-    const inserted = rows.map(insert_row => promisify(sheet.addRow)(insert_row))
-    log.info(`Wrote ${inserted.length} rows.`)
-    return Promise.all(inserted)
-  }
-  log.info('Wrong sheet!')
-}
-
 function eventCountsToStatusCounts(events: { [s in VEHICLE_EVENT]: number }) {
   return (Object.keys(events) as VEHICLE_EVENT[]).reduce(
     (acc: { [s in VEHICLE_STATUS]: number }, event) => {
@@ -91,6 +76,78 @@ function eventCountsToStatusCounts(events: { [s in VEHICLE_EVENT]: number }) {
       elsewhere: 0
     }
   )
+}
+
+const mapProviderToPayload = (provider: VehicleCountRow, last: LastDayStatsResponse) => {
+  const dateOptions = { timeZone: 'America/Los_Angeles', day: '2-digit', month: '2-digit', year: 'numeric' }
+  const timeOptions = { timeZone: 'America/Los_Angeles', hour12: false, hour: '2-digit', minute: '2-digit' }
+  const d = new Date()
+  let [enters, leaves, starts, ends, start_sla, end_sla, telems, telem_sla] = [0, 0, 0, 0, 0, 0, 0, 0]
+  let event_counts = { service_start: 0, provider_drop_off: 0, trip_start: 0, trip_end: 0 }
+  let status_counts = {
+    available: 0,
+    unavailable: 0,
+    reserved: 0,
+    trip: 0,
+    removed: 0,
+    inactive: 0,
+    elsewhere: 0
+  }
+  const { event_counts_last_24h } = last[provider.provider_id]
+  if (event_counts_last_24h) {
+    event_counts = event_counts_last_24h
+    status_counts = eventCountsToStatusCounts(event_counts_last_24h)
+    starts = event_counts_last_24h.trip_start || 0
+    ends = event_counts_last_24h.trip_end || 0
+    enters = event_counts_last_24h.trip_enter || 0
+    leaves = event_counts_last_24h.trip_leave || 0
+    telems = last[provider.provider_id].telemetry_counts_last_24h || 0
+    telem_sla = telems ? percent(last[provider.provider_id].late_telemetry_counts_last_24h, telems) : 0
+    start_sla = starts ? percent(last[provider.provider_id].late_event_counts_last_24h.trip_start, starts) : 0
+    end_sla = ends ? percent(last[provider.provider_id].late_event_counts_last_24h.trip_end, ends) : 0
+  }
+  return {
+    date: `${d.toLocaleDateString('en-US', dateOptions)} ${d.toLocaleTimeString('en-US', timeOptions)}`,
+    name: provider.provider,
+    registered: provider.count || 0,
+    deployed:
+      sum([provider.status.available, provider.status.unavailable, provider.status.trip, provider.status.reserved]) ||
+      0,
+    validtrips: 'tbd', // Placeholder for next day valid trip analysis
+    trips: last[provider.provider_id].trips_last_24h || 0,
+    servicestart: event_counts.service_start || 0,
+    providerdropoff: event_counts.provider_drop_off || 0,
+    tripstart: starts,
+    tripend: ends,
+    tripenter: enters,
+    tripleave: leaves,
+    telemetry: telems,
+    telemetrysla: telem_sla,
+    tripstartsla: start_sla,
+    tripendsla: end_sla,
+    available: status_counts.available,
+    unavailable: status_counts.unavailable,
+    reserved: status_counts.reserved,
+    trip: status_counts.trip,
+    removed: status_counts.removed,
+    inactive: status_counts.inactive,
+    elsewhere: status_counts.elsewhere
+  }
+}
+
+async function appendSheet(sheetName: string, rows: MetricsSheetRow[]) {
+  const doc = new GoogleSpreadsheet(process.env.SPREADSHEET_ID)
+  await promisify(doc.useServiceAccountAuth)(creds)
+  const info = await promisify(doc.getInfo)()
+  log.info(`Loaded doc: ${info.title} by ${info.author.email}`)
+  const sheet = info.worksheets.filter((s: { title: string; rowCount: number } & unknown) => s.title === sheetName)[0]
+  log.info(`${sheetName} sheet: ${sheet.title} ${sheet.rowCount}x${sheet.colCount}`)
+  if (sheet.title === sheetName) {
+    const inserted = rows.map(insert_row => promisify(sheet.addRow)(insert_row))
+    log.info(`Wrote ${inserted.length} rows.`)
+    return Promise.all(inserted)
+  }
+  log.info('Wrong sheet!')
 }
 
 async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
@@ -128,63 +185,7 @@ async function getProviderMetrics(iter: number): Promise<MetricsSheetRow[]> {
 
     const rows: MetricsSheetRow[] = counts
       .filter(p => reportProviders.includes(p.provider_id))
-      .map(provider => {
-        const dateOptions = { timeZone: 'America/Los_Angeles', day: '2-digit', month: '2-digit', year: 'numeric' }
-        const timeOptions = { timeZone: 'America/Los_Angeles', hour12: false, hour: '2-digit', minute: '2-digit' }
-        const d = new Date()
-        let [starts, ends, start_sla, end_sla, telems, telem_sla] = [0, 0, 0, 0, 0, 0]
-        let event_counts = { service_start: 0, provider_drop_off: 0, trip_start: 0, trip_end: 0 }
-        let status_counts = {
-          available: 0,
-          unavailable: 0,
-          reserved: 0,
-          trip: 0,
-          removed: 0,
-          inactive: 0,
-          elsewhere: 0
-        }
-        if (last[provider.provider_id].event_counts_last_24h) {
-          event_counts = last[provider.provider_id].event_counts_last_24h
-          status_counts = eventCountsToStatusCounts(last[provider.provider_id].event_counts_last_24h)
-          starts = last[provider.provider_id].event_counts_last_24h.trip_start || 0
-          ends = last[provider.provider_id].event_counts_last_24h.trip_end || 0
-          telems = last[provider.provider_id].telemetry_counts_last_24h || 0
-          telem_sla = telems ? percent(last[provider.provider_id].late_telemetry_counts_last_24h, telems) : 0
-          start_sla = starts ? percent(last[provider.provider_id].late_event_counts_last_24h.trip_start, starts) : 0
-          end_sla = ends ? percent(last[provider.provider_id].late_event_counts_last_24h.trip_end, ends) : 0
-        }
-        return {
-          date: `${d.toLocaleDateString('en-US', dateOptions)} ${d.toLocaleTimeString('en-US', timeOptions)}`,
-          name: provider.provider,
-          registered: provider.count || 0,
-          deployed:
-            sum([
-              provider.status.available,
-              provider.status.unavailable,
-              provider.status.trip,
-              provider.status.reserved
-            ]) || 0,
-          validtrips: 'tbd', // Placeholder for next day valid trip analysis
-          trips: last[provider.provider_id].trips_last_24h || 0,
-          servicestart: event_counts.service_start || 0,
-          providerdropoff: event_counts.provider_drop_off || 0,
-          tripstart: starts,
-          tripend: ends,
-          tripenter: last[provider.provider_id].event_counts_last_24h.trip_enter || 0,
-          tripleave: last[provider.provider_id].event_counts_last_24h.trip_leave || 0,
-          telemetry: telems,
-          telemetrysla: telem_sla,
-          tripstartsla: start_sla,
-          tripendsla: end_sla,
-          available: status_counts.available,
-          unavailable: status_counts.unavailable,
-          reserved: status_counts.reserved,
-          trip: status_counts.trip,
-          removed: status_counts.removed,
-          inactive: status_counts.inactive,
-          elsewhere: status_counts.elsewhere
-        }
-      })
+      .map(provider => mapProviderToPayload(provider, last))
     return rows
   } catch (err) {
     await log.error('getProviderMetrics', err)
@@ -200,3 +201,5 @@ export const MetricsLogHandler = async () => {
     await log.error('MetricsLogHandler', err)
   }
 }
+
+export { mapProviderToPayload }

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 50 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
   },
   "author": "City of Los Angeles",
   "license": "Apache-2.0",

--- a/packages/mds-metrics-sheet/package.json
+++ b/packages/mds-metrics-sheet/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build tsconfig.build.json",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
-    "test:unit": "exit 0"
+    "test:unit": "DOTENV_CONFIG_PATH=../../.env nyc --check-coverage --exclude tests --extension .ts --lines 65 --reporter=text --reporter=html ts-mocha --project ../../tsconfig.json --require tsconfig-paths/register --require source-map-support/register --require dotenv/config --recursive tests/**/*.ts"
   },
   "author": "City of Los Angeles",
   "license": "Apache-2.0",

--- a/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
+++ b/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import uuid from 'uuid'
-import { mapProviderToPayload } from '../metrics-log'
+import { mapProviderToPayload, eventCountsToStatusCounts, sum, percent } from '../metrics-log'
 import { VehicleCountRow, LastDayStatsResponse } from '../types'
 
 const getStatus = (): VehicleCountRow['status'] => {
@@ -17,8 +17,21 @@ const getStatus = (): VehicleCountRow['status'] => {
 
 const getEvent = (): VehicleCountRow['event_type'] => {
   return {
-    // TODO type out these fields
-  } as VehicleCountRow['event_type']
+    register: 42,
+    service_start: 42,
+    service_end: 42,
+    provider_drop_off: 42,
+    provider_pick_up: 42,
+    agency_pick_up: 42,
+    agency_drop_off: 42,
+    reserve: 42,
+    cancel_reservation: 42,
+    trip_start: 42,
+    trip_enter: 42,
+    trip_leave: 42,
+    trip_end: 42,
+    deregister: 42
+  }
 }
 
 const getLastDayStatsResponse = (provider_id: string): LastDayStatsResponse => {
@@ -27,14 +40,45 @@ const getLastDayStatsResponse = (provider_id: string): LastDayStatsResponse => {
     [provider_id]: {
       trips_last_24h: 1,
       ms_since_last_event: 5582050,
-      late_event_counts_last_24h: {},
       telemetry_counts_last_24h: 5,
       late_telemetry_counts_last_24h: 1,
       events_last_24h: 3,
       events_not_in_conformance: 1,
-      name: 'fake-name'
+      name: 'fake-name',
+      event_counts_last_24h: {
+        register: 42,
+        service_start: 42,
+        service_end: 42,
+        provider_drop_off: 42,
+        provider_pick_up: 42,
+        agency_pick_up: 42,
+        agency_drop_off: 42,
+        reserve: 42,
+        cancel_reservation: 42,
+        trip_start: 42,
+        trip_enter: 42,
+        trip_leave: 42,
+        trip_end: 42,
+        deregister: 42
+      },
+      late_event_counts_last_24h: {
+        register: 42,
+        service_start: 42,
+        service_end: 42,
+        provider_drop_off: 42,
+        provider_pick_up: 42,
+        agency_pick_up: 42,
+        agency_drop_off: 42,
+        reserve: 42,
+        cancel_reservation: 42,
+        trip_start: 42,
+        trip_enter: 42,
+        trip_leave: 42,
+        trip_end: 42,
+        deregister: 42
+      }
     }
-  } as LastDayStatsResponse
+  }
 }
 
 const getProvider = (): VehicleCountRow => {
@@ -49,41 +93,177 @@ const getProvider = (): VehicleCountRow => {
   }
 }
 
-const getExpectedPayload = (date: string) => {
-  return {
-    date,
-    name: 'fake-provider',
-    registered: 42,
-    deployed: 72,
-    validtrips: 'tbd',
-    trips: 1,
-    servicestart: 0,
-    providerdropoff: 0,
-    tripstart: 0,
-    tripend: 0,
-    tripenter: 0,
-    tripleave: 0,
-    telemetry: 0,
-    telemetrysla: 0,
-    tripstartsla: 0,
-    tripendsla: 0,
-    available: 0,
-    unavailable: 0,
-    reserved: 0,
-    trip: 0,
-    removed: 0,
-    inactive: 0,
-    elsewhere: 0
-  }
-}
-
 describe('MDS Metrics Sheet', () => {
-  describe('Metrics Log', () => {
+  describe('Utility functions', () => {
+    it('Maps event counts to status counts', () => {
+      const event = {
+        register: 42,
+        service_start: 42,
+        service_end: 42,
+        provider_drop_off: 42,
+        provider_pick_up: 42,
+        agency_pick_up: 42,
+        agency_drop_off: 42,
+        reserve: 42,
+        cancel_reservation: 42,
+        trip_start: 42,
+        trip_enter: 42,
+        trip_leave: 42,
+        trip_end: 42,
+        deregister: 42
+      }
+      const result = eventCountsToStatusCounts(event)
+      const expected = {
+        available: 210,
+        elsewhere: 42,
+        inactive: 42,
+        removed: 126,
+        reserved: 42,
+        trip: 84,
+        unavailable: 42
+      }
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Computes `sum()` correctly', () => {
+      const arr = [1, 2, 3]
+      assert.equal(sum(arr), 6)
+    })
+
+    it('Computes `percent()` correctly', () => {
+      assert.equal(percent(9, 100), 0.91)
+    })
+  })
+
+  describe('Metrics Log mapping function', () => {
     it('Maps a provider to the correct payload', () => {
       const provider = getProvider()
       const lastDayStatsResponse = getLastDayStatsResponse(provider.provider_id)
       const result = mapProviderToPayload(provider, lastDayStatsResponse)
-      const expected = getExpectedPayload(result.date)
+      const expected = {
+        date: result.date,
+        name: 'fake-provider',
+        registered: 42,
+        deployed: 72,
+        validtrips: 'tbd',
+        trips: 1,
+        servicestart: 42,
+        providerdropoff: 42,
+        tripstart: 42,
+        tripend: 42,
+        tripenter: 42,
+        tripleave: 42,
+        telemetry: 5,
+        telemetrysla: 0.8,
+        tripstartsla: 0,
+        tripendsla: 0,
+        available: 210,
+        unavailable: 42,
+        reserved: 42,
+        trip: 84,
+        removed: 126,
+        inactive: 42,
+        elsewhere: 42
+      }
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Maps `lastDayStatsResponse` sans `event_counts_last_24h` to the correct payload', () => {
+      const provider = getProvider()
+      const lastDayStatsResponse = getLastDayStatsResponse(provider.provider_id)
+      lastDayStatsResponse[provider.provider_id].event_counts_last_24h = undefined
+      const result = mapProviderToPayload(provider, lastDayStatsResponse)
+      const expected = {
+        date: result.date,
+        name: 'fake-provider',
+        registered: 42,
+        deployed: 72,
+        validtrips: 'tbd',
+        trips: 1,
+        servicestart: 0,
+        providerdropoff: 0,
+        tripstart: 0,
+        tripend: 0,
+        tripenter: 0,
+        tripleave: 0,
+        telemetry: 0,
+        telemetrysla: 0,
+        tripstartsla: 0,
+        tripendsla: 0,
+        available: 0,
+        unavailable: 0,
+        reserved: 0,
+        trip: 0,
+        removed: 0,
+        inactive: 0,
+        elsewhere: 0
+      }
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Maps `lastDayStatsResponse` sans `late_telemetry_counts_last_24h` to the correct payload', () => {
+      const provider = getProvider()
+      const lastDayStatsResponse = getLastDayStatsResponse(provider.provider_id)
+      lastDayStatsResponse[provider.provider_id].late_telemetry_counts_last_24h = undefined
+      const result = mapProviderToPayload(provider, lastDayStatsResponse)
+      const expected = {
+        date: result.date,
+        name: 'fake-provider',
+        registered: 42,
+        deployed: 72,
+        validtrips: 'tbd',
+        trips: 1,
+        servicestart: 42,
+        providerdropoff: 42,
+        tripstart: 42,
+        tripend: 42,
+        tripenter: 42,
+        tripleave: 42,
+        telemetry: 5,
+        telemetrysla: 0,
+        tripstartsla: 0,
+        tripendsla: 0,
+        available: 210,
+        unavailable: 42,
+        reserved: 42,
+        trip: 84,
+        removed: 126,
+        inactive: 42,
+        elsewhere: 42
+      }
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Maps `lastDayStatsResponse` sans `late_event_counts_last_24h` to the correct payload', () => {
+      const provider = getProvider()
+      const lastDayStatsResponse = getLastDayStatsResponse(provider.provider_id)
+      lastDayStatsResponse[provider.provider_id].late_event_counts_last_24h = undefined
+      const result = mapProviderToPayload(provider, lastDayStatsResponse)
+      const expected = {
+        date: result.date,
+        name: 'fake-provider',
+        registered: 42,
+        deployed: 72,
+        validtrips: 'tbd',
+        trips: 1,
+        servicestart: 42,
+        providerdropoff: 42,
+        tripstart: 42,
+        tripend: 42,
+        tripenter: 42,
+        tripleave: 42,
+        telemetry: 5,
+        telemetrysla: 0.8,
+        tripstartsla: 0,
+        tripendsla: 0,
+        available: 210,
+        unavailable: 42,
+        reserved: 42,
+        trip: 84,
+        removed: 126,
+        inactive: 42,
+        elsewhere: 42
+      }
       assert.deepStrictEqual(result, expected)
     })
   })

--- a/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
+++ b/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
@@ -1,0 +1,90 @@
+import assert from 'assert'
+import uuid from 'uuid'
+import { mapProviderToPayload } from '../metrics-log'
+import { VehicleCountRow, LastDayStatsResponse } from '../types'
+
+const getStatus = (): VehicleCountRow['status'] => {
+  return {
+    available: 42,
+    reserved: 20,
+    unavailable: 5,
+    removed: 0,
+    inactive: 3,
+    trip: 5,
+    elsewhere: 17
+  }
+}
+
+const getEvent = (): VehicleCountRow['event_type'] => {
+  return {
+    // TODO type out these fields
+  } as VehicleCountRow['event_type']
+}
+
+const getLastDayStatsResponse = (provider_id: string): LastDayStatsResponse => {
+  return {
+    // TODO type out
+    [provider_id]: {
+      trips_last_24h: 1,
+      ms_since_last_event: 5582050,
+      late_event_counts_last_24h: {},
+      telemetry_counts_last_24h: 5,
+      late_telemetry_counts_last_24h: 1,
+      events_last_24h: 3,
+      events_not_in_conformance: 1,
+      name: 'fake-name'
+    }
+  } as LastDayStatsResponse
+}
+
+const getProvider = (): VehicleCountRow => {
+  return {
+    provider_id: uuid(),
+    provider: 'fake-provider',
+    count: 42,
+    status: getStatus(),
+    event_type: getEvent(),
+    areas: {},
+    areas_48h: {}
+  }
+}
+
+const getExpectedPayload = (date: string) => {
+  return {
+    date,
+    name: 'fake-provider',
+    registered: 42,
+    deployed: 72,
+    validtrips: 'tbd',
+    trips: 1,
+    servicestart: 0,
+    providerdropoff: 0,
+    tripstart: 0,
+    tripend: 0,
+    tripenter: 0,
+    tripleave: 0,
+    telemetry: 0,
+    telemetrysla: 0,
+    tripstartsla: 0,
+    tripendsla: 0,
+    available: 0,
+    unavailable: 0,
+    reserved: 0,
+    trip: 0,
+    removed: 0,
+    inactive: 0,
+    elsewhere: 0
+  }
+}
+
+describe('MDS Metrics Sheet', () => {
+  describe('Metrics Log', () => {
+    it('Maps a provider to the correct payload', () => {
+      const provider = getProvider()
+      const lastDayStatsResponse = getLastDayStatsResponse(provider.provider_id)
+      const result = mapProviderToPayload(provider, lastDayStatsResponse)
+      const expected = getExpectedPayload(result.date)
+      assert.deepStrictEqual(result, expected)
+    })
+  })
+})

--- a/packages/mds-metrics-sheet/types.ts
+++ b/packages/mds-metrics-sheet/types.ts
@@ -14,14 +14,14 @@ export type VehicleCountResponse = VehicleCountRow[]
 
 export interface LastDayStatsResponse {
   [s: string]: {
-    trips_last_24h: number
-    ms_since_last_event: 5582050
+    trips_last_24h?: number
+    ms_since_last_event?: 5582050
     event_counts_last_24h?: { [s in VEHICLE_EVENT]: number }
-    late_event_counts_last_24h: { [s in VEHICLE_EVENT]: number }
-    telemetry_counts_last_24h: number
-    late_telemetry_counts_last_24h: number
-    events_last_24h: number
-    events_not_in_conformance: number
+    late_event_counts_last_24h?: { [s in VEHICLE_EVENT]: number }
+    telemetry_counts_last_24h?: number
+    late_telemetry_counts_last_24h?: number
+    events_last_24h?: number
+    events_not_in_conformance?: number
     name: string
   }
 }

--- a/packages/mds-metrics-sheet/types.ts
+++ b/packages/mds-metrics-sheet/types.ts
@@ -1,6 +1,6 @@
 import { UUID, VEHICLE_STATUS, VEHICLE_EVENT } from '@mds-core/mds-types'
 
-interface VehicleCountRow {
+export interface VehicleCountRow {
   provider_id: UUID
   provider: string
   count: number
@@ -16,7 +16,7 @@ export interface LastDayStatsResponse {
   [s: string]: {
     trips_last_24h: number
     ms_since_last_event: 5582050
-    event_counts_last_24h: { [s in VEHICLE_EVENT]: number }
+    event_counts_last_24h?: { [s in VEHICLE_EVENT]: number }
     late_event_counts_last_24h: { [s in VEHICLE_EVENT]: number }
     telemetry_counts_last_24h: number
     late_telemetry_counts_last_24h: number


### PR DESCRIPTION
This should squash this lambda log error:

2019-09-18T07:00:45.559Z 0c7fca82-d644-4985-8b37-15cbcd440f5e ERROR ERROR getProviderMetrics TypeError: Cannot read property 'trip_enter' of undefined

Testing plan:

1. Run test suite

## PR Checklist

 - [ X] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ X] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


