### PR TITLE
allow commits even if ~/.aws not present

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,6 @@
   hooks:
     - id: trailing-whitespace
     - id: detect-aws-credentials
+      args: [--allow-missing-credentials]
     - id: detect-private-key
     - id: check-merge-conflict


### PR DESCRIPTION
Successfully tested with this very commit.