### PR TITLE
installer: +metrics-adapter, vary mds-namespace, more docs, discreet ns ops

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -75,11 +75,11 @@ declare -A apps=(
   ["mds-compliance"]="https://localhost:[port]/compliance,mds,app"
   ["mds-daily"]="https://localhost:[port]/daily,mds,app"
   ["mds-native"]="https://localhost:[port]/native,mds,app"
-  ["mds-policy"]="https://localhost:[port]/provider,mds,app"
+  ["mds-policy"]="https://localhost:[port]/policy,mds,app"
   ["mds-provider"]="https://localhost:[port]/provider,mds,app"
-  ["mds-policy-author"]="https://localhost:[port]/provider,mds,app"
-  ["mds-postgresql"]="https://localhost:[port]/provider,mds,app,postgresql"
-  ["mds-redis"]="https://localhost:[port]/provider,mds,app,redis"
+  ["mds-policy-author"]="https://localhost:[port]/policy-author,mds,app"
+  ["mds-postgresql"]="https://localhost:[port]/postgresql,mds,app,postgresql"
+  ["mds-redis"]="https://localhost:[port]/redis,mds,app,redis"
   ["dashboard"]="https://localhost:[port],dashboard,k8s-app,kubernetes-dashboard"
   ["grafana"]="http://localhost:[port]/dashboard/db/istio-mesh-dashboard,istio-system,app"
   ["kibana"]="http://localhost:[port],logging,app"
@@ -636,7 +636,7 @@ getPort() {
     gp=$(get ${ga} 5 -1)
 
     [ ${gp} -eq -1 ] && {
-      (( $(kubectl -n kube-system get pod -l k8s-app=kubernetes-dashboard | wc -l) == 1 )) &&
+      (( $(kubectl -n ${gns} get pod -l ${gk}=${gv} | wc -l) == 2 )) &&
         gp=$(kubectl -n ${gns} get pod -l ${gk}=${gv} \
           -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}')
     }

--- a/bin/install
+++ b/bin/install
@@ -556,11 +556,13 @@ uninstallSimulator() {
 }
 
 uninstallFallbackCertificate() {
-  echo tbd
+  kubectl get secret gateway-fallback > /dev/null 2>&1 &&
+    kubectl delete secret gateway-fallback
 }
 
 uninstallIngressGatewayCertificate() {
-  echo tbd
+  kubectl get secret istio-ingressgateway-certs > /dev/null 2>&1 &&
+    kubectl delete secret istio-ingressgateway-certs
 }
 
 uninstallMetricsAdapter() {

--- a/bin/install
+++ b/bin/install
@@ -358,9 +358,8 @@ installMds() {
 }
 
 installMetricsAdapter() {
-  kubectl get namespace metrics-adapter > /dev/null 2>&1 || {
-    helm install --name metrics-adapter --namespace metrics-adapter banzaicloud-stable/kube-metrics-adapter
-  }
+  helm status kube-metrics-adapter > /dev/null 2>&1 ||
+    helm install --name kube-metrics-adapter --namespace kube-system banzaicloud-stable/kube-metrics-adapter
 }
 
 installFallbackCertificate() {
@@ -539,8 +538,8 @@ cliRedis() {
 
 uninstallNamespace() {
   for ns in ${@}; do
-    echo "kubectl get namespace ${1} > /dev/null 2>&1 && kubectl delete namespace ${ns} \
-      ${configs[dryrun]:+--dry-run}"
+    kubectl get namespace ${1} > /dev/null 2>&1 && kubectl delete namespace ${ns} \
+      ${configs[dryrun]:+--dry-run}
   done; unset ns
 }
 
@@ -565,7 +564,7 @@ uninstallIngressGatewayCertificate() {
 }
 
 uninstallMetricsAdapter() {
-  helm delete --purge metrics-adapter
+  helm status kube-metrics-adapter > /dev/null 2>&1 && helm delete --purge kube-metrics-adapter
 }
 
 uninstallMds() {

--- a/bin/install
+++ b/bin/install
@@ -61,6 +61,8 @@ declare -A configs=(
   ["sets-mds"]="${MDS_SETS_MDS:-pgPass=Password123#}"
   ["setfiles"]="${MDS_SET_FILES:-}"
   ["setfiles-mds"]="${MDS_SET_FILES_MDS:-}"
+  ["namespace"]="${MDS_NAMESPACE:-default}"
+  ["namespace-mds"]="${MDS_NAMESPACE_MDS}"
   ["dryrun"]="${MDS_DRY_RUN:-}")
 declare -A helmRepositories=(
   ["stable"]="https://kubernetes-charts.storage.googleapis.com"
@@ -128,8 +130,9 @@ where service in:
   kiali
   istio
   mds
-  fallbackCertificate
-  ingressGatewayCertificate
+  fallbackCertificate                                 : requires ingress domain; eg: -c:ingress-domain=[DOMAIN]
+  ingressGatewayCertificate                           : requires certificate path; eg: -c:ingress-gateway-key-path=[KEY-PATH],ingress-gateway-certificate-path=[CERT-PATH]
+  metricsAdapter
   logging
   metrics
   bookinfo
@@ -170,13 +173,14 @@ bootstrap() {
     hash ${lc} > /dev/null 2>&1 || {
       brew install ${l}
 
+      # todo: unable to detect nvm install via subshell given it is an alias
       if [ "${l}" == "nvm" ]; then
         [ ! -d ~/.nmv ] && mkdir -p ~/.nvm
         [ $(grep -Fxq "export NMV_DIR=\"${HOME}\"" ~/.bashrc; echo $?) == "1" ] && \
           echo "export NMV_DIR=\"${HOME}\"" >> ~/.bashrc
         [ $(grep -Fxq "eval sh \$(brew --prefix nvm)/nvm.sh" ~/.bashrc; echo $?) == "1" ] && \
               echo "eval sh \$(brew --prefix nvm)/nvm.sh" >> ~/.bashrc
-        sh $(brew --prefix nvm)/nvm.sh
+        . $(brew --prefix nvm)/nvm.sh
         nvm install node
         nvm use node
         nvm install 8.10.0
@@ -266,6 +270,12 @@ installDashboard() {
     ${configs[dryrun]:+--dry-run}
 }
 
+installNamespace() {
+  for ns in ${@}; do
+    kubectl get namespace ${ns} > /dev/null 2>&1 || kubectl create namespace ${ns} ${configs[dryrun]:+--dry-run}
+  done; unset ns
+}
+
 installIstio() {
   check ${FUNCNAME[0]}
 
@@ -277,7 +287,7 @@ installIstio() {
   kubectl get namespace istio-system > /dev/null 2>&1 || {
     ${configs[istio]}/bin/istioctl verify-install || error "istio verify installation failure"
 
-    kubectl create namespace istio-system ${configs[dryrun]:+--dry-run}
+    installNamespace istio-system
     pause 2
     helm template ${configs[istio]}/install/kubernetes/helm/istio-init \
       --name istio-init --namespace istio-system | \
@@ -305,7 +315,7 @@ installLogging() {
   check ${FUNCNAME[0]}
 
   kubectl get namespace logging > /dev/null 2>&1 || {
-    kubectl create namespace logging ${configs[dryrun]:+--dry-run}
+    installNamespace logging
     labelNamespaceIstioInjection logging
     helm install ./helm/logging --name logging --namespace logging \
       ${configs[values]:+$(helmOptions values ${configs[values]})} \
@@ -319,7 +329,7 @@ installMetrics() {
   check ${FUNCNAME[0]}
 
   kubectl get namespace metrics > /dev/null 2>&1 || {
-    kubectl create namespace metrics ${configs[dryrun]:+--dry-run}
+    installNamespace metrics
     helm install ./helm/metrics --name metrics --namespace metrics \
       ${configs[values]:+$(helmOptions values ${configs[values]})} \
       ${configs[setfiles]:+$(helmOptions set ${configs[setfiles]})} \
@@ -332,10 +342,10 @@ installMds() {
   check ${FUNCNAME[0]}
 
   installFallbackCertificate
-  kubectl get namespace mds > /dev/null 2>&1 || {
-    kubectl create namespace mds ${configs[dryrun]:+--dry-run}
-    labelNamespaceIstioInjection mds
-    helm install ./helm/mds --name mds --namespace mds \
+  kubectl get namespace ${configs[namespace-mds]:-mds} > /dev/null 2>&1 || {
+    installNamespace ${configs[namespace-mds]:-mds}
+    labelNamespaceIstioInjection ${configs[namespace-mds]:-mds}
+    helm install ./helm/mds --name mds --namespace ${configs[namespace-mds]:-mds} \
       ${configs[values]:+$(helmOptions values ${configs[values]})} \
       ${configs[values-mds]:+$(helmOptions values ${configs[values-mds]})} \
       ${configs[sets]:+$(helmOptions set ${configs[sets]})} \
@@ -344,6 +354,12 @@ installMds() {
       ${configs[setfiles-mds]:+$(helmOptions set-file ${configs[setfiles-mds]})} \
       ${configs[dryrun]:+--dry-run --debug}
     pause 12
+  }
+}
+
+installMetricsAdapter() {
+  kubectl get namespace metrics-adapter > /dev/null 2>&1 || {
+    helm install --name metrics-adapter --namespace metrics-adapter banzaicloud-stable/kube-metrics-adapter
   }
 }
 
@@ -394,7 +410,7 @@ installBookinfo() {
   check ${FUNCNAME[0]}
 
   kubectl get namespace bookinfo-app > /dev/null 2>&1 || {
-    kubectl create namespace bookinfo-app ${configs[dryrun]:+--dry-run}
+    installNamespace bookinfo-app
     labelNamespaceIstioInjection bookinfo-app
     kubectl apply -n bookinfo-app -f ${configs[istio]}/samples/bookinfo/platform/kube/bookinfo.yaml \
       ${configs[dryrun]:+--dry-run}
@@ -521,15 +537,15 @@ cliRedis() {
   redis-cli -u redis://localhost:6379/0
 }
 
-uninstallNamespaces() {
+uninstallNamespace() {
   for ns in ${@}; do
-    kubectl get namespace ${1} > /dev/null 2>&1 && kubectl delete namespace ${ns} \
-      ${configs[dryrun]:+--dry-run}
+    echo "kubectl get namespace ${1} > /dev/null 2>&1 && kubectl delete namespace ${ns} \
+      ${configs[dryrun]:+--dry-run}"
   done; unset ns
 }
 
 uninstallBookinfo() {
-  uninstallNamespaces bookinfo-app
+  uninstallNamespace bookinfo-app
 }
 
 uninstallSimulator() {
@@ -540,16 +556,28 @@ uninstallSimulator() {
   [ -d ${configs[simulator]} ] && /bin/rm -rf ${configs[simulator]}
 }
 
+uninstallFallbackCertificate() {
+  echo tbd
+}
+
+uninstallIngressGatewayCertificate() {
+  echo tbd
+}
+
+uninstallMetricsAdapter() {
+  helm delete --purge metrics-adapter
+}
+
 uninstallMds() {
   check ${FUNCNAME[0]}
   helm delete --purge mds ${configs[dryrun]:+--dry-run}
-  uninstallNamespaces mds
+  uninstallNamespace ${configs[namespace-mds]:-mds}
 }
 
 uninstallMetrics() {
   check ${FUNCNAME[0]}
   helm delete --purge metrics ${configs[dryrun]:+--dry-run}
-  uninstallNamespaces metrics
+  uninstallNamespace metrics
 }
 
 uninstallLogging() {
@@ -560,7 +588,7 @@ uninstallLogging() {
 uninstallKiali() {
   unforward kiali
   helm delete --purge kiali
-  uninstallNamespaces kiali
+  uninstallNamespace kiali
   # kubectl delete secrets kubernetes-dashboard-key-holder -n kube-system ${configs[dryrun]:+--dry-run}
   kubectl get namespace kiali > /dev/null 2>&1 && kubectl delete namespace kiali \
     ${configs[dryrun]:+--dry-run}
@@ -584,7 +612,7 @@ uninstallIstio() {
 uninstallDashboard() {
   unforward dashboard
   helm delete --purge dashboard
-  uninstallNamespaces dashboard
+  uninstallNamespace dashboard
   kubectl delete secrets kubernetes-dashboard-key-holder -n kube-system ${configs[dryrun]:+--dry-run}
   kubectl get namespace dashboard > /dev/null 2>&1 && kubectl delete namespace dashboard \
     ${configs[dryrun]:+--dry-run}
@@ -668,7 +696,7 @@ invoke() {
 }
 
 normalize() {
-  echo ${1} | cut -d ':' -f 2- | tr ',' ' '
+  echo ${1} | cut -d ${2:-:} -f 2- | tr ',' ' '
 }
 
 configure() {
@@ -695,6 +723,7 @@ for arg in "${@}"; do
   case "${arg}" in
     bootstrap) bootstrap || warn  "${arg} failure";;
     build) build || usage "${arg} failure";;
+    install:namespace=*) installNamespace "$(normalize ${arg} =)";;
     install) arg="${configs[install]}";&
     install:*) invoke install "$(normalize ${arg})";;
     test) arg="${configs[test]}";&
@@ -708,6 +737,7 @@ for arg in "${@}"; do
     open) usage "specify an application(s) to open";;
     open:*) app "$(normalize ${arg})";;
     cli:*) invoke cli "$(normalize ${arg})";;
+    uninstall:namespace=*) uninstallNamespace "$(normalize ${arg} =)";;
     uninstall) arg="${configs[uninstall]}";&
     uninstall:*) invoke uninstall "$(normalize ${arg})";;
     reinstall) arg="${configs[reinstall]}";&

--- a/bin/install
+++ b/bin/install
@@ -176,10 +176,10 @@ bootstrap() {
       # todo: unable to detect nvm install via subshell given it is an alias
       if [ "${l}" == "nvm" ]; then
         [ ! -d ~/.nmv ] && mkdir -p ~/.nvm
-        [ $(grep -Fxq "export NMV_DIR=\"${HOME}\"" ~/.bashrc; echo $?) == "1" ] && \
-          echo "export NMV_DIR=\"${HOME}\"" >> ~/.bashrc
-        [ $(grep -Fxq "eval sh \$(brew --prefix nvm)/nvm.sh" ~/.bashrc; echo $?) == "1" ] && \
-              echo "eval sh \$(brew --prefix nvm)/nvm.sh" >> ~/.bashrc
+        [ $(grep -Fxq "export NMV_DIR=\"\${HOME}/.nvm\"" ~/.bashrc; echo $?) == "1" ] && \
+          echo "export NMV_DIR=\"\${HOME}/.nvm\"" >> ~/.bashrc
+        [ $(grep -Fxq "eval . \$(brew --prefix nvm)/nvm.sh" ~/.bashrc; echo $?) == "1" ] && \
+              echo "eval . \$(brew --prefix nvm)/nvm.sh" >> ~/.bashrc
         . $(brew --prefix nvm)/nvm.sh
         nvm install node
         nvm use node

--- a/helm/dashboard/Chart.yaml
+++ b/helm/dashboard/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.10.1"
+description: Dashboard
+name: kubernetes-dashboard
+version: 1.10.1

--- a/helm/dashboard/templates/kubernetes-dashboard.yaml
+++ b/helm/dashboard/templates/kubernetes-dashboard.yaml
@@ -1,0 +1,162 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ------------------- Dashboard Secret ------------------- #
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-certs
+  namespace: {{ $.Release.Namespace }}
+type: Opaque
+
+---
+# ------------------- Dashboard Service Account ------------------- #
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: {{ $.Release.Namespace }}
+
+---
+# ------------------- Dashboard Role & Role Binding ------------------- #
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: {{ $.Release.Namespace }}
+rules:
+  # Allow Dashboard to create 'kubernetes-dashboard-key-holder' secret.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+  # Allow Dashboard to create 'kubernetes-dashboard-settings' config map.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
+  verbs: ["get", "update", "delete"]
+  # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["kubernetes-dashboard-settings"]
+  verbs: ["get", "update"]
+  # Allow Dashboard to get metrics from heapster.
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster", "http:heapster:", "https:heapster:"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubernetes-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: {{ $.Release.Namespace }}
+
+---
+# ------------------- Dashboard Deployment ------------------- #
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: {{ $.Release.Namespace }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      containers:
+      - name: kubernetes-dashboard
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+        args:
+          - --auto-generate-certificates
+          # Uncomment the following line to manually specify Kubernetes API server Host
+          # If not specified, Dashboard will attempt to auto discover the API server and connect
+          # to it. Uncomment only if the default does not work.
+          # - --apiserver-host=http://my-address:port
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /
+            port: 8443
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+
+---
+# ------------------- Dashboard Service ------------------- #
+
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: {{ $.Release.Namespace }}
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    k8s-app: kubernetes-dashboard

--- a/helm/dashboard/templates/service-account.yaml
+++ b/helm/dashboard/templates/service-account.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: {{ $.Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: {{ $.Release.Namespace }}


### PR DESCRIPTION
* (un)install:metricsAdapter
  * banzaicloud-stable/kube-metrics-adapter named kube-metrics-adapter in the namespace kub-system
* ability to vary mds-namespace
  * eg '% ./bin/install -c:namespace-mds=foo install:mds
* better documentation/usage-message for install:fallbackCertificate,ingressGatewayCertificate
  * as they both require additional configs (ie domain and key/cert path respectively)
* support discreet install:namespace=a,b,c operation
  * noting: at present bin/install uses namespace existence as a pre-install guard
* make dashboard work again
* make cli:[postgresql,redis] work again

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


