### PR TITLE
[mds-daily] Fix lambda error

### DIFF
--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -377,7 +377,7 @@ async function readEvents(device_ids: UUID[]): Promise<VehicleEvent[]> {
     .filter(e => !!e)
 }
 
-async function readAllEvents() {
+async function readAllEvents() : Promise<Array<VehicleEvent | null>> {
   // FIXME wildcard searching is slow
   const keys = await readKeys('device:*:event')
   const device_ids = keys.map(key => {

--- a/packages/mds-daily/request-handlers.ts
+++ b/packages/mds-daily/request-handlers.ts
@@ -1,6 +1,5 @@
 import db from '@mds-core/mds-db'
 import log from '@mds-core/mds-logger'
-import cache from '@mds-core/mds-cache'
 import { providerName } from '@mds-core/mds-providers'
 import { now, inc, ServerError } from '@mds-core/mds-utils'
 import { UUID, VehicleEvent, VEHICLE_STATUSES, EVENT_STATUS_MAP, VEHICLE_EVENT, TripsStats } from '@mds-core/mds-types'
@@ -15,7 +14,7 @@ import {
   getTelemetryCountsPerProviderSince,
   getConformanceLast24Hours
 } from './db-helpers'
-import { startAndEnd, categorizeTrips } from './utils'
+import { startAndEnd, categorizeTrips, getMaps } from './utils'
 
 export async function dbHelperFail(err: Error | string): Promise<void> {
   await log.error(
@@ -64,32 +63,6 @@ export async function getVehicleCounts(req: DailyApiRequest, res: DailyApiRespon
     res.status(500).send({
       error: err
     })
-  }
-
-  async function getMaps(): Promise<{
-    eventMap: { [s: string]: VehicleEvent }
-    // telemetryMap: { [s: string]: Telemetry }
-  }> {
-    try {
-      // const telemetry: Telemetry[] = await cache.readAllTelemetry()
-      // log.info('read telemetry')
-      const events: VehicleEvent[] = await cache.readAllEvents()
-      log.info('read events')
-      const eventSeed: { [s: string]: VehicleEvent } = {}
-      const eventMap: { [s: string]: VehicleEvent } = events.reduce((map, event) => {
-        return Object.assign(map, { [event.device_id]: event })
-      }, eventSeed)
-      // const telemetrySeed: { [s: string]: Telemetry } = {}
-      // const telemetryMap = telemetry.reduce((map, t) => {
-      //   return Object.assign(map, { [t.device_id]: t })
-      // }, telemetrySeed)
-      return Promise.resolve({
-        // telemetryMap,
-        eventMap
-      })
-    } catch (err) {
-      return Promise.reject(err)
-    }
   }
 
   try {

--- a/packages/mds-daily/tests/request-handlers.test.ts
+++ b/packages/mds-daily/tests/request-handlers.test.ts
@@ -3,6 +3,8 @@ import Sinon from 'sinon'
 import { DailyApiRequest, DailyApiResponse } from '../types'
 import { getRawTripData } from '../request-handlers'
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 describe('Request handlers', () => {
   describe('getRawTripData()', () => {
     it('handles a db read error in getRawTripData()', async () => {

--- a/packages/mds-daily/tests/utils.test.ts
+++ b/packages/mds-daily/tests/utils.test.ts
@@ -1,5 +1,7 @@
 import assert from 'assert'
-import { categorizeTrips, TripsData, asInt } from '../utils'
+import cache from '@mds-core/mds-cache'
+import Sinon from 'sinon'
+import { categorizeTrips, TripsData, asInt, getMaps } from '../utils'
 
 describe('MDS Daily utils', () => {
   describe('asInt()', () => {
@@ -49,5 +51,11 @@ describe('MDS Daily utils', () => {
       }
       assert.deepStrictEqual(result, expected)
     })
+  })
+
+  it('Computes event mapping correctly even with cache miss', async () => {
+    Sinon.replace(cache, 'readAllEvents', Sinon.fake.resolves([null]))
+    const maps = await getMaps()
+    assert.deepStrictEqual(maps, { eventMap: {} })
   })
 })

--- a/packages/mds-daily/utils.ts
+++ b/packages/mds-daily/utils.ts
@@ -1,5 +1,7 @@
 import { isTimestamp, now, days, inc, head, tail } from '@mds-core/mds-utils'
-import { UUID, CountMap, TripsStats, VEHICLE_EVENTS } from '@mds-core/mds-types'
+import { UUID, CountMap, TripsStats, VEHICLE_EVENTS, VehicleEvent } from '@mds-core/mds-types'
+import cache from '@mds-core/mds-cache'
+import log from '@mds-core/mds-logger'
 
 // TODO move to utils?
 export function asInt(n: string | number | undefined): number | undefined {
@@ -98,4 +100,30 @@ export function categorizeTrips(perTripId: TripsData): { [s: string]: TripsStats
     Object.assign(perProvider[pid], counts)
   })
   return perProvider
+}
+
+export async function getMaps(): Promise<{
+  eventMap: { [s: string]: VehicleEvent }
+  // telemetryMap: { [s: string]: Telemetry }
+}> {
+  try {
+    // const telemetry: Telemetry[] = await cache.readAllTelemetry()
+    // log.info('read telemetry')
+    const events = await cache.readAllEvents()
+    log.info('read events')
+    const eventSeed: { [s: string]: VehicleEvent } = {}
+    const eventMap: { [s: string]: VehicleEvent } = events.reduce((map, event) => {
+      return event ? Object.assign(map, { [event.device_id]: event }) : map
+    }, eventSeed)
+    // const telemetrySeed: { [s: string]: Telemetry } = {}
+    // const telemetryMap = telemetry.reduce((map, t) => {
+    //   return Object.assign(map, { [t.device_id]: t })
+    // }, telemetrySeed)
+    return Promise.resolve({
+      // telemetryMap,
+      eventMap
+    })
+  } catch (err) {
+    return Promise.reject(err)
+  }
 }


### PR DESCRIPTION
This is an attempt to triage this error
`/admin/vehicle_counts fail TypeError: Cannot read property 'device_id' of null`

I haven't been able to pull specific log info yet, so it's just a guess as to the problem. Likely we're just running into a cache miss, so we're getting an unexpected `null` in the cache results, so I just added some branching logic to deal with that case.

## PR Checklist

 - [ X] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ X] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [X ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ X] Daily
- [ ] Native
- [ ] Policy Author


