### PR TITLE
[draft] first attempt to fully-qualify object names for purposes of rolling updates

### DIFF
--- a/helm/mds/templates/_helpers.tpl
+++ b/helm/mds/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mds.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mds.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Chart.Version $.Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mds.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "mds.labels" -}}
+app.kubernetes.io/name: {{ include "mds.name" . }}
+helm.sh/chart: {{ include "mds.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/helm/mds/templates/auth.yaml
+++ b/helm/mds/templates/auth.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   targets:
-  - name: {{ $api.name }}
+  - name: {{ include "mds.fullname" $ }}-{{ $api.name }}
   peers:
   - mtls: {}
   origins:

--- a/helm/mds/templates/auth.yaml
+++ b/helm/mds/templates/auth.yaml
@@ -4,7 +4,7 @@
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: {{ $api.name }}-auth
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-auth
   namespace: {{ $.Release.Namespace }}
 spec:
   targets:

--- a/helm/mds/templates/auth.yaml
+++ b/helm/mds/templates/auth.yaml
@@ -4,7 +4,7 @@
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-auth
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-{{ $api.version }}-auth
   namespace: {{ $.Release.Namespace }}
 spec:
   targets:

--- a/helm/mds/templates/autoscaler.yaml
+++ b/helm/mds/templates/autoscaler.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ $api.name }}-hpa
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-hpa
   namespace: {{ $.Release.Namespace }}
   annotations:
     metric-config.object.istio-requests-total.prometheus/per-replica: "true"

--- a/helm/mds/templates/autoscaler.yaml
+++ b/helm/mds/templates/autoscaler.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-hpa
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-{{ $api.version }}-hpa
   namespace: {{ $.Release.Namespace }}
   annotations:
     metric-config.object.istio-requests-total.prometheus/per-replica: "true"

--- a/helm/mds/templates/autoscaler.yaml
+++ b/helm/mds/templates/autoscaler.yaml
@@ -29,7 +29,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ $api.name }}
+    name: {{ include "mds.fullname" $ }}-{{ $api.name }}
   metrics:
     - type: Object
       object:
@@ -37,7 +37,7 @@ spec:
         target:
           apiVersion: v1
           kind: Pod
-          name: {{ $api.name }}
+          name: {{ include "mds.fullname" $ }}-{{ $api.name }}
         targetValue: 10
 ---
 {{- end }}

--- a/helm/mds/templates/cronjob.yaml
+++ b/helm/mds/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: metrics-sheet
+  name: {{ include "mds.fullname" $ }}-metrics-sheet-cronjob
   namespace: {{ $.Release.Namespace }}
 spec:
   schedule: "*/1 * * * *"
@@ -38,7 +38,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: metrics-sheet
+  name: {{ include "mds.fullname" $ }}-metrics-sheet
   namespace: {{ $.Release.Namespace }}
 type: Opaque
 data:

--- a/helm/mds/templates/deployment.yaml
+++ b/helm/mds/templates/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $api.name }}
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-deployment
   labels:
     app: {{ $api.name }}
   namespace: {{ $.Release.Namespace }}
@@ -96,7 +96,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pg-pass
+  name: {{ include "mds.fullname" $ }}-pg-pass
   namespace: {{ $.Release.Namespace }}
 type: Opaque
 data:

--- a/helm/mds/templates/deployment.yaml
+++ b/helm/mds/templates/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-deployment
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-{{ $api.version }}-deployment
   labels:
     app: {{ $api.name }}
   namespace: {{ $.Release.Namespace }}

--- a/helm/mds/templates/deployment.yaml
+++ b/helm/mds/templates/deployment.yaml
@@ -5,17 +5,17 @@ kind: Deployment
 metadata:
   name: {{ include "mds.fullname" $ }}-{{ $api.name }}-{{ $api.version }}-deployment
   labels:
-    app: {{ $api.name }}
+    app: {{ include "mds.fullname" $ }}-{{ $api.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ $api.name }}
+      app: {{ include "mds.fullname" $ }}-{{ $api.name }}
   template:
     metadata:
       labels:
-        app: {{ $api.name }}
+        app: {{ include "mds.fullname" $ }}-{{ $api.name }}
     spec:
       containers:
       - name: {{ $api.name }}

--- a/helm/mds/templates/egress.yaml
+++ b/helm/mds/templates/egress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: pg-rw-external
+  name: {{ include "mds.fullname" $ }}-pg-rw-external
   namespace: {{ .Release.Namespace }}
 spec:
   hosts:
@@ -17,7 +17,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: pg-ro-external
+  name: {{ include "mds.fullname" $ }}-pg-ro-external
   namespace: {{ .Release.Namespace }}
 spec:
   hosts:
@@ -34,7 +34,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: redis-external
+  name: {{ include "mds.fullname" $ }}-redis-external
   namespace: {{ .Release.Namespace }}
 spec:
   hosts:
@@ -50,7 +50,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: fluentbit-output
+  name: {{ include "mds.fullname" $ }}-fluentbit-output
   namespace: {{ .Release.Namespace }}
 spec:
   hosts:

--- a/helm/mds/templates/ingress.yaml
+++ b/helm/mds/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-route
+  name: {{ include "mds.fullname" $ }}-{{ $api.version }}-{{ $api.name }}-route
   namespace: {{ $.Release.Namespace }}
 spec:
   hosts:

--- a/helm/mds/templates/ingress.yaml
+++ b/helm/mds/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ $api.name }}-route
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}-route
   namespace: {{ $.Release.Namespace }}
 spec:
   hosts:
@@ -48,7 +48,7 @@ spec:
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: ingress-cert
+  name: {{ include "mds.fullname" $ }}-ingress-cert
   namespace: istio-system
 spec:
   secretName: ingress-cert
@@ -64,7 +64,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: mds-gateway
+  name: {{ include "mds.fullname" $ }}-mds-gateway
   namespace: {{ .Release.Namespace }}
 spec:
   selector:

--- a/helm/mds/templates/ingress.yaml
+++ b/helm/mds/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
     - destination:
         port:
           number: {{ $api.port }}
-        host: {{ $api.name }}.{{ $.Release.Namespace}}.svc.cluster.local
+        host: {{ $api.name }}.{{ $.Release.Namespace }}.svc.cluster.local
     corsPolicy:
       allowOrigin:
       - "*"

--- a/helm/mds/templates/service.yaml
+++ b/helm/mds/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   selector:
-    app: {{ $api.name }}
+    app: {{ include "mds.fullname" $ }}-{{ $api.name }}
   ports:
   -
     name: http-{{ $api.name }}

--- a/helm/mds/templates/service.yaml
+++ b/helm/mds/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "mds.fullname" $ }}-{{ $api.name }}
+  name: {{ include "mds.fullname" $ }}-{{ $api.version }}-{{ $api.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
   selector:

--- a/helm/mds/templates/service.yaml
+++ b/helm/mds/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $api.name }}
+  name: {{ include "mds.fullname" $ }}-{{ $api.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
   selector:


### PR DESCRIPTION
add modified helper-template with full-name function that composites the following fields:

  release-name + release-version + service-name + service-version + kind

applied this strategy to every name attribute, in all likelihood too much so.

additionally, we should verify reference-names are not broken by this change.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-0.0.1-mds-policy-author-latest-deployment
```

note: tests will need to be updated prior to commit

reference: https://www.youtube.com/watch?v=9cwjtN3gkD4&feature=youtu.be&t=470

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [x] Provider
- [x] Agency
- [x] Audit
- [x] Policy
- [x] Compliance
- [x] Daily
- [x] Native
- [x] Policy Author


