### PR TITLE
suffix the container image tag based on the current git branch

### DIFF
--- a/bin/image-build
+++ b/bin/image-build
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Tag images built outside of the master branch with a
+# "-prerelease" suffix for deployment safety.
+
+IMAGE="$1"
+BRANCH="$(git branch --no-color --show-current)"
+
+case $BRANCH in
+  master)
+    SUFFIX="";;
+  *)
+    SUFFIX="-prerelease";;
+esac
+
+docker build -t ${IMAGE}${SUFFIX} .
+docker tag ${IMAGE}${SUFFIX} latest

--- a/container-images/mds-agency/package.json
+++ b/container-images/mds-agency/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-agency:${npm_package_version} . && docker tag mds-agency:${npm_package_version} mds-agency:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-agency:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-audit/package.json
+++ b/container-images/mds-audit/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-audit:${npm_package_version} . && docker tag mds-audit:${npm_package_version} mds-audit:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-audit:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-compliance/package.json
+++ b/container-images/mds-compliance/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-compliance:${npm_package_version} . && docker tag mds-compliance:${npm_package_version} mds-compliance:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-compliance:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-daily/package.json
+++ b/container-images/mds-daily/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-daily:${npm_package_version} . && docker tag mds-daily:${npm_package_version} mds-daily:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-daily:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-metrics-sheet/package.json
+++ b/container-images/mds-metrics-sheet/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-metrics-sheet:${npm_package_version} . && docker tag mds-metrics-sheet:${npm_package_version} mds-metrics-sheet:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-metrics-sheet:${npm_package_version}",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",
     "test:unit": "exit 0"

--- a/container-images/mds-native/package.json
+++ b/container-images/mds-native/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-native:${npm_package_version} . && docker tag mds-native:${npm_package_version} mds-native:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-native:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-policy-author/package.json
+++ b/container-images/mds-policy-author/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-policy-author:${npm_package_version} . && docker tag mds-policy-author:${npm_package_version} mds-policy-author:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-policy-author:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-policy/package.json
+++ b/container-images/mds-policy/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-policy:${npm_package_version} . && docker tag mds-policy:${npm_package_version} mds-policy:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-policy:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",

--- a/container-images/mds-provider/package.json
+++ b/container-images/mds-provider/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "bundle": "yarn build && webpack --mode=production --env.npm_package_name=${npm_package_name} --env.npm_package_version=${npm_package_version}",
-    "image": "yarn bundle && docker build -t mds-provider:${npm_package_version} . && docker tag mds-provider:${npm_package_version} mds-provider:latest",
+    "image": "yarn bundle && ../../bin/image-build mds-provider:${npm_package_version}",
     "start": "yarn watch server",
     "test": "yarn test:eslint && yarn test:unit",
     "test:eslint": "eslint --fix --ignore-path ../../.gitignore '**/*.ts'",


### PR DESCRIPTION
Moves the docker build command from `package.json` to a utility script, so that we can check the current branch and suffix the container image tag as needed.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


