### PR TITLE
Fix env-inject when running MDS APIs in Docker

### DIFF
--- a/container-images/env-inject/index.ts
+++ b/container-images/env-inject/index.ts
@@ -21,12 +21,11 @@ declare const NPM_PACKAGE_GIT_BRANCH: string
 declare const NPM_PACKAGE_GIT_COMMIT: string
 declare const NPM_PACKAGE_BUILD_DATE: string
 
-export function env() {
-  return Object.assign(process.env, {
+export const env = () =>
+  Object.assign(process.env, {
     npm_package_name: NPM_PACKAGE_NAME,
     npm_package_version: NPM_PACKAGE_VERSION,
     npm_package_git_branch: NPM_PACKAGE_GIT_BRANCH,
     npm_package_git_commit: NPM_PACKAGE_GIT_COMMIT,
     npm_package_build_date: NPM_PACKAGE_BUILD_DATE
   })
-}

--- a/container-images/env-inject/index.ts
+++ b/container-images/env-inject/index.ts
@@ -21,8 +21,8 @@ declare const NPM_PACKAGE_GIT_BRANCH: string
 declare const NPM_PACKAGE_GIT_COMMIT: string
 declare const NPM_PACKAGE_BUILD_DATE: string
 
-export function setEnv() {
-  Object.assign(process.env, {
+export function env() {
+  return Object.assign(process.env, {
     npm_package_name: NPM_PACKAGE_NAME,
     npm_package_version: NPM_PACKAGE_VERSION,
     npm_package_git_branch: NPM_PACKAGE_GIT_BRANCH,

--- a/container-images/mds-agency/index.ts
+++ b/container-images/mds-agency/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-agency'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4001 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4001 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-agency/index.ts
+++ b/container-images/mds-agency/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-agency'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4001 }
-} = process
+const { npm_package_name, PORT = 4001 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-audit/index.ts
+++ b/container-images/mds-audit/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-audit'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4002 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4002 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-audit/index.ts
+++ b/container-images/mds-audit/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-audit'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4002 }
-} = process
+const { npm_package_name, PORT = 4002 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-compliance/index.ts
+++ b/container-images/mds-compliance/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-compliance'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4004 }
-} = process
+const { npm_package_name, PORT = 4004 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-compliance/index.ts
+++ b/container-images/mds-compliance/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-compliance'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4004 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4004 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-daily/index.ts
+++ b/container-images/mds-daily/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-daily'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4005 }
-} = process
+const { npm_package_name, PORT = 4005 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-daily/index.ts
+++ b/container-images/mds-daily/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-daily'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4005 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4005 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-native/index.ts
+++ b/container-images/mds-native/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-native'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4006 }
-} = process
+const { npm_package_name, PORT = 4006 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-native/index.ts
+++ b/container-images/mds-native/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-native'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4006 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4006 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-policy-author/index.ts
+++ b/container-images/mds-policy-author/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-policy-author'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4007 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4007 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-policy-author/index.ts
+++ b/container-images/mds-policy-author/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-policy-author'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4007 }
-} = process
+const { npm_package_name, PORT = 4007 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-policy/index.ts
+++ b/container-images/mds-policy/index.ts
@@ -17,13 +17,9 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-policy'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4003 }
-} = process
-
-setEnv()
+const { npm_package_name, PORT = 4003 } = env()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))

--- a/container-images/mds-policy/index.ts
+++ b/container-images/mds-policy/index.ts
@@ -19,7 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-policy'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4003 } = env()
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4003 } = env()
+
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-provider/index.ts
+++ b/container-images/mds-provider/index.ts
@@ -19,8 +19,10 @@ import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-provider'
 import { env } from '@container-images/env-inject'
 
-const { npm_package_name, PORT = 4000 } = env()
+const { npm_package_name, npm_package_version, npm_package_git_commit, PORT = 4000 } = env()
 
-/* eslint-reason avoids import of logger */
-/* eslint-disable-next-line no-console */
-ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))
+ApiServer(api).listen(PORT, () =>
+  /* eslint-reason avoids import of logger */
+  /* eslint-disable-next-line no-console */
+  console.log(`${npm_package_name} v${npm_package_version} (${npm_package_git_commit}) running on port ${PORT}`)
+)

--- a/container-images/mds-provider/index.ts
+++ b/container-images/mds-provider/index.ts
@@ -17,13 +17,10 @@
 // Express local
 import { ApiServer } from '@mds-core/mds-api-server'
 import { api } from '@mds-core/mds-provider'
-import { setEnv } from '@container-images/env-inject'
+import { env } from '@container-images/env-inject'
 
-const {
-  env: { npm_package_name, PORT = 4000 }
-} = process
+const { npm_package_name, PORT = 4000 } = env()
 
-setEnv()
 /* eslint-reason avoids import of logger */
 /* eslint-disable-next-line no-console */
 ApiServer(api).listen(PORT, () => console.log(`${npm_package_name} running on port ${PORT}`))


### PR DESCRIPTION
When running in Docker at startup, the APIs were logging messages like:

`undefined running on port 4000`

They now log:

`@container-images/mds-provider v0.1.9 (cd230ac) running on port 4000`

## Impacts
- [x] Provider
- [x] Agency
- [x] Audit
- [x] Policy
- [x] Compliance
- [x] Daily
- [x] Native
- [x] Policy Author


