### PR TITLE
[mds-metrics-sheet] Refactor row mapping + add test

### DIFF
--- a/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
+++ b/packages/mds-metrics-sheet/tests/mds-metrics-sheet.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 import uuid from 'uuid'
 import { mapProviderToPayload, eventCountsToStatusCounts, sum, percent } from '../metrics-log'
 import { VehicleCountRow, LastDayStatsResponse } from '../types'
+import { computeRow } from '../vehicle-counts'
 
 const getStatus = (): VehicleCountRow['status'] => {
   return {
@@ -266,5 +267,27 @@ describe('MDS Metrics Sheet', () => {
       }
       assert.deepStrictEqual(result, expected)
     })
+  })
+
+  it('Computes row mapping correctly', () => {
+    const veniceAreaKeys = ['Venice', 'Venice Beach', 'Venice Canals', 'Venice Beach Special Operations Zone']
+    const row = {
+      areas_48h: {},
+      provider: 'fake-provider'
+    } as VehicleCountRow
+    for (const veniceAreaKey of veniceAreaKeys) {
+      row.areas_48h[veniceAreaKey] = 5
+    }
+    const mappedRow = computeRow(row)
+    const expectedMappedRow = {
+      date: mappedRow.date, // A bit weird to copy this over...but I don't want to mock Date()
+      name: row.provider,
+      'Venice Area': 20,
+      Venice: 5,
+      'Venice Beach': 5,
+      'Venice Canals': 5,
+      'Venice Beach Special Operations Zone': 5
+    }
+    assert.deepStrictEqual(mappedRow, expectedMappedRow)
   })
 })

--- a/packages/mds-metrics-sheet/vehicle-counts.ts
+++ b/packages/mds-metrics-sheet/vehicle-counts.ts
@@ -32,7 +32,7 @@ import {
   BOLT_PROVIDER_ID
 } from '@mds-core/mds-providers'
 
-import { VehicleCountResponse } from './types'
+import { VehicleCountResponse, VehicleCountRow } from './types'
 
 // The list of providers ids on which to report
 const reportProviders = [
@@ -66,6 +66,26 @@ async function appendSheet(sheetName: string, rows: ({ date: string; name: strin
   log.info('Wrong sheet!')
 }
 
+export function computeRow(row: VehicleCountRow) {
+  const dateOptions = { timeZone: 'America/Los_Angeles', day: '2-digit', month: '2-digit', year: 'numeric' }
+  const timeOptions = { timeZone: 'America/Los_Angeles', hour12: false, hour: '2-digit', minute: '2-digit' }
+  const d = new Date()
+  let veniceAreaSum = 0
+  const veniceAreaKeys = ['Venice', 'Venice Beach', 'Venice Canals', 'Venice Beach Special Operations Zone']
+  for (const veniceAreaKey of veniceAreaKeys) {
+    veniceAreaSum += row.areas_48h[veniceAreaKey] || 0
+  }
+  const augmentedRow = {
+    'Venice Area': veniceAreaSum,
+    ...row.areas_48h
+  }
+  return {
+    date: `${d.toLocaleDateString('en-US', dateOptions)} ${d.toLocaleTimeString('en-US', timeOptions)}`,
+    name: row.provider,
+    ...augmentedRow
+  }
+}
+
 async function getProviderMetrics(iter: number): Promise<({ date: string; name: string } & unknown)[]> {
   /* after 10 failed iterations, give up */
   if (iter >= 10) {
@@ -96,25 +116,7 @@ async function getProviderMetrics(iter: number): Promise<({ date: string; name: 
     const counts: VehicleCountResponse = await requestPromise(counts_options)
     const rows: ({ date: string; name: string } & unknown)[] = counts
       .filter(p => reportProviders.includes(p.provider_id))
-      .map(row => {
-        const dateOptions = { timeZone: 'America/Los_Angeles', day: '2-digit', month: '2-digit', year: 'numeric' }
-        const timeOptions = { timeZone: 'America/Los_Angeles', hour12: false, hour: '2-digit', minute: '2-digit' }
-        const d = new Date()
-        let veniceAreaSum = 0
-        const veniceAreaKeys = ['Venice', 'Venice Beach', 'Venice Canals', 'Venice Beach Special Operations Zone']
-        for (const veniceAreaKey of veniceAreaKeys) {
-          veniceAreaSum += row.areas_48h[veniceAreaKey] || 0
-        }
-        const augmentedRow = {
-          'Venice Area': veniceAreaSum,
-          ...row.areas_48h
-        }
-        return {
-          date: `${d.toLocaleDateString('en-US', dateOptions)} ${d.toLocaleTimeString('en-US', timeOptions)}`,
-          name: row.provider,
-          ...augmentedRow
-        }
-      })
+      .map(computeRow)
     return rows
   } catch (err) {
     await log.error('getProviderMetrics', err)


### PR DESCRIPTION
Note: the base `yarn build` seems to be failing as of commit 5d1406a59665d517883d7574e125017111ee32d9, but PR #210 should patch things up ok, then we can toss a rebase onto this.

Adds a basic test to the row mapping functionality in metrics sheet, while summing up all the venice areas into the `venice area` column.

## PR Checklist

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [x] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [x] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author
- [x] Metrics Sheet


