### PR TITLE
[mds-db] [mds-policy-author] [mds-policy] Automatically populate start_date, effective_date fields of a Geograp…

### DIFF
--- a/packages/mds-cache/index.ts
+++ b/packages/mds-cache/index.ts
@@ -377,7 +377,7 @@ async function readEvents(device_ids: UUID[]): Promise<VehicleEvent[]> {
     .filter(e => !!e)
 }
 
-async function readAllEvents() : Promise<Array<VehicleEvent | null>> {
+async function readAllEvents(): Promise<Array<VehicleEvent | null>> {
   // FIXME wildcard searching is slow
   const keys = await readKeys('device:*:event')
   const device_ids = keys.map(key => {

--- a/packages/mds-db/tests/mds-db.spec.ts
+++ b/packages/mds-db/tests/mds-db.spec.ts
@@ -397,7 +397,7 @@ if (pg_info.database) {
         const noGeos = await MDSDBPostgres.readGeographies({ get_read_only: true })
         assert.deepEqual(noGeos.length, 0)
 
-        await MDSDBPostgres.publishGeography(LAGeography.geography_id)
+        await MDSDBPostgres.publishGeography({ geography_id: LAGeography.geography_id, effective_date: now() })
         const writeableGeographies = await MDSDBPostgres.readGeographies({ get_read_only: false })
         assert.deepEqual(writeableGeographies.length, 1)
       })
@@ -455,6 +455,20 @@ if (pg_info.database) {
         await MDSDBPostgres.publishPolicy(POLICY3_JSON.policy_id)
         assert(await MDSDBPostgres.isGeographyPublished(DistrictSeven.geography_id))
         assert(await MDSDBPostgres.isGeographyPublished(LAGeography.geography_id))
+
+        const LAgeo = await MDSDBPostgres.readSingleGeography(LAGeography.geography_id)
+        assert(LAgeo.publish_date)
+        assert.deepEqual(LAgeo.effective_date, POLICY3_JSON.start_date)
+      })
+
+      it('will update the effective_date of a Geography if another Policy publishes it', async () => {
+        const LAgeoBefore = await MDSDBPostgres.readSingleGeography(LAGeography.geography_id)
+        await MDSDBPostgres.writePolicy(POLICY_JSON)
+        await MDSDBPostgres.publishPolicy(POLICY_JSON.policy_id)
+
+        const LAgeoAfter = await MDSDBPostgres.readSingleGeography(LAGeography.geography_id)
+        assert.deepEqual(LAgeoBefore.publish_date, LAgeoAfter.publish_date)
+        assert.deepEqual(LAgeoAfter.effective_date, POLICY_JSON.start_date)
       })
     })
 


### PR DESCRIPTION
…hy when a Policy is published.

## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


