### PR TITLE
adds unit tests for sandbox admin

### DIFF
--- a/packages/mds-agency/tests/sandbox-admin-request-handlers.ts
+++ b/packages/mds-agency/tests/sandbox-admin-request-handlers.ts
@@ -1,0 +1,137 @@
+import Sinon from 'sinon'
+import assert from 'assert'
+import uuid from 'uuid'
+import cache from '@mds-core/mds-cache'
+import db from '@mds-core/mds-db'
+import { AgencyApiRequest, AgencyApiResponse } from '../types'
+import { getCacheInfo, wipeDevice, refreshCache } from '../sandbox-admin-request-handlers'
+import * as utils from '../utils'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('Sandbox admin request handlers', () => {
+  describe('Gets cache info', () => {
+    it('Gets cache info', async () => {
+      const res: AgencyApiResponse = {} as AgencyApiResponse
+      const sendHandler = Sinon.fake.returns('asdf')
+      const statusHandler = Sinon.fake.returns({
+        send: sendHandler
+      } as any)
+      res.status = statusHandler
+      Sinon.replace(cache, 'info', Sinon.fake.resolves('it-worked'))
+      await getCacheInfo({} as AgencyApiRequest, res)
+      assert.equal(statusHandler.calledWith(200), true)
+      Sinon.restore()
+    })
+    it('Fails to get cache info', async () => {
+      const res: AgencyApiResponse = {} as AgencyApiResponse
+      const sendHandler = Sinon.fake.returns('asdf')
+      const statusHandler = Sinon.fake.returns({
+        send: sendHandler
+      } as any)
+      res.status = statusHandler
+      Sinon.replace(cache, 'info', Sinon.fake.rejects('it-failed'))
+      await getCacheInfo({} as AgencyApiRequest, res)
+      assert.equal(statusHandler.calledWith(500), true)
+      Sinon.restore()
+    })
+  })
+  describe('It wipes device', () => {
+    it('Fails to wipe device', async () => {
+      const provider_id = uuid()
+      const device_id = uuid()
+      const res: AgencyApiResponse = {} as AgencyApiResponse
+      const sendHandler = Sinon.fake.returns('asdf')
+      const statusHandler = Sinon.fake.returns({
+        send: sendHandler
+      } as any)
+      res.status = statusHandler
+      res.locals = { provider_id } as any
+      Sinon.replace(cache, 'wipeDevice', Sinon.fake.rejects('it-failed'))
+      Sinon.replace(db, 'wipeDevice', Sinon.fake.rejects('it-failed'))
+      await wipeDevice(
+        {
+          params: { device_id },
+          query: { cached: false },
+          get: Sinon.fake.returns('foo') as any
+        } as AgencyApiRequest,
+        res
+      )
+      assert.equal(statusHandler.calledWith(500), true)
+      Sinon.restore()
+    })
+    it('Successfully wipes device', async () => {
+      const provider_id = uuid()
+      const device_id = uuid()
+      const res: AgencyApiResponse = {} as AgencyApiResponse
+      const sendHandler = Sinon.fake.returns('asdf')
+      const statusHandler = Sinon.fake.returns({
+        send: sendHandler
+      } as any)
+      res.status = statusHandler
+      res.locals = { provider_id } as any
+      Sinon.replace(cache, 'wipeDevice', Sinon.fake.resolves(1))
+      Sinon.replace(db, 'wipeDevice', Sinon.fake.resolves('it-worked'))
+      await wipeDevice(
+        {
+          params: { device_id },
+          query: { cached: false },
+          get: Sinon.fake.returns('foo') as any
+        } as AgencyApiRequest,
+        res
+      )
+      assert.equal(statusHandler.calledWith(200), true)
+      Sinon.restore()
+    })
+  })
+  describe('Refresh cache', () => {
+    it('Successfully refreshes cache', async () => {
+      const provider_id = uuid()
+      const device_id = uuid()
+      const res: AgencyApiResponse = {} as AgencyApiResponse
+      const sendHandler = Sinon.fake.returns('asdf')
+      const statusHandler = Sinon.fake.returns({
+        send: sendHandler
+      } as any)
+      res.status = statusHandler
+      res.locals = { provider_id } as any
+      Sinon.replace(db, 'readDeviceIds', Sinon.fake.resolves([1]))
+      Sinon.replace(utils, 'refresh', Sinon.fake.resolves([1]))
+      await refreshCache(
+        {
+          params: { device_id },
+          query: { cached: false },
+          get: Sinon.fake.returns('foo') as any
+        } as AgencyApiRequest,
+        res
+      )
+      assert.equal(statusHandler.calledWith(200), true)
+      // Sinon.replace(db, 'wipeDevice', Sinon.fake.resolves('it-worked'))
+      Sinon.restore()
+    })
+    it('Fails to refreshes cache', async () => {
+      const provider_id = uuid()
+      const device_id = uuid()
+      const res: AgencyApiResponse = {} as AgencyApiResponse
+      const sendHandler = Sinon.fake.returns('asdf')
+      const statusHandler = Sinon.fake.returns({
+        send: sendHandler
+      } as any)
+      res.status = statusHandler
+      res.locals = { provider_id } as any
+      Sinon.replace(db, 'readDeviceIds', Sinon.fake.rejects('it-fails'))
+      Sinon.replace(utils, 'refresh', Sinon.fake.rejects('it-fails'))
+      await refreshCache(
+        {
+          params: { device_id },
+          query: { cached: false },
+          get: Sinon.fake.returns('foo') as any
+        } as AgencyApiRequest,
+        res
+      )
+      assert.equal(statusHandler.calledWith(500), true)
+      // Sinon.replace(db, 'wipeDevice', Sinon.fake.resolves('it-worked'))
+      Sinon.restore()
+    })
+  })
+})


### PR DESCRIPTION
## PR Checklist

Adds unit tests for sandbox-admin, cleans up status codes and adds error handling to getCacheInfo call.

 - [x] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [x] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [x] write tests for all new functionality

## Impacts
- [ ] Provider
- [x] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


