### PR TITLE
presets

### DIFF
--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 osx=Darwin
 linux=Linux
 

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+
 osx=Darwin
 linux=Linux
 
@@ -57,8 +58,10 @@ declare -A configs=(
   ["ingress-gateway-certificate-path"]="${MDS_INGRESS_GATEWAY_CERTIFICATE_PATH:-}"
   ["values"]="${MDS_VALUES:-}"
   ["values-mds"]="${MDS_VALUES_MDS:-}"
+  ["presets"]="${MDS_PRESETS:-}"
+  ["presets-mds"]="${MDS_PRESETS_MDS:-pgPass=Password123#,apis.mds-agency.migration=true}"
   ["sets"]="${MDS_SETS:-}"
-  ["sets-mds"]="${MDS_SETS_MDS:-pgPass=Password123#,apis.mds-agency.migration=true}"
+  ["sets-mds"]="${MDS_SETS_MDS:-}"
   ["setfiles"]="${MDS_SET_FILES:-}"
   ["setfiles-mds"]="${MDS_SET_FILES_MDS:-}"
   ["namespace"]="${MDS_NAMESPACE:-default}"
@@ -174,11 +177,11 @@ EOF
 
 bootstrap() {
   for l in ${configs[brew]}; do
+    lc=${l}
     case ${l} in
       kubernetes-helm) lc=helm;;
       gettext) lc=envsubst;;
       oq) brew tap blacksmoke16/tap;;
-      *) lc=${l};;
     esac
 
     hash ${lc} > /dev/null 2>&1 || {
@@ -408,6 +411,8 @@ installMds() {
     helm install ./helm/mds --name mds --namespace ${configs[namespace-mds]:-mds} \
       ${configs[values]:+$(helmOptions values ${configs[values]})} \
       ${configs[values-mds]:+$(helmOptions values ${configs[values-mds]})} \
+      ${configs[presets]:+$(helmOptions set ${configs[presets]})} \
+      ${configs[presets-mds]:+$(helmOptions set ${configs[presets-mds]})} \
       ${configs[sets]:+$(helmOptions set ${configs[sets]})} \
       ${configs[sets-mds]:+$(helmOptions set ${configs[sets-mds]})} \
       ${configs[setfiles]:+$(helmOptions set-file ${configs[setfiles]})} \
@@ -775,7 +780,7 @@ configure() {
       k=$(echo ${c} | cut -d '=' -f 1)
       v=$(echo ${c} | cut -d '=' -f 2-)
 
-      [[ "${k}" == *"+" ]] && configs[${k%+}]+=",${v}" || configs[${k}]="${v}"
+      [[ "${k}" == *"+" ]] && configs[${k%+}]+="${configs[${k%+}]:+,}${v}" || configs[${k}]="${v}"
     done; unset c k v
   else
     configs[${1}]=
@@ -787,13 +792,16 @@ preset() {
     case ${p} in
       disable)
         for s in $(oq -i yaml -r '.apis | keys[]' ./helm/mds/values.yaml); do
-          is+="${is:+,}sets-mds+=apis.${s}.enabled=false"
+          is+="${is:+,}presets-mds+=apis.${s}.enabled=false"
         done; unset s;;
       local)
-        is+="${is:+,}sets-mds+=resourcesLimitsCpu=200m,sets-mds+=resourcesLimitsMemory=200Mi,sets-mds+=resourcesRequestsCpu=20m,sets-mds+=resourcesRequestsMemory=32Mi";;
+        is+="${is:+,}presets-mds+=resourcesLimitsCpu=200m"
+        is+="${is:+,}presets-mds+=resourcesLimitsMemory=200Mi"
+        is+="${is:+,}presets-mds+=resourcesRequestsCpu=20m"
+        is+="${is:+,}presets-mds+=resourcesRequestsMemory=32Mi";;
       minimal)
         preset $(normalize "disable,local")
-        configs[sets-mds]=${configs[sets-mds]//apis.mds-agency.enabled=false/apis.mds-agency.enabled=true};;
+        is+="${is:+,}sets-mds+=apis.mds-agency.enabled=true";;
     esac
   done; unset p
 

--- a/bin/mdsctl
+++ b/bin/mdsctl
@@ -123,6 +123,7 @@ options:
   --configure:{key}={value}[,{key}={value}]           : set configuration value by key
   --configure:{key}+={value}                          : append configuration value by key
   --configure:{key}=                                  : clears configuration value by key
+  --preset:[preset-key[,preset-key]]                  : preset configurations
 
 where service in:
   helm
@@ -155,6 +156,11 @@ where app in:
   jaeger                                              : jaeger; see https://www.jaegertracing.io
   kiali                                               : kiali; see https://www.kiali.io
   bookinfo                                            : bookinfo; see https://istio.io/docs/examples/bookinfo
+
+where preset-key in:
+  minimal                                             : minimal service deployment; default: preset(local) + mds-agency, postgresql, redis
+  local                                               : local resource (cpu, memory) deployment; default: limitsCpu=200m, limitsMemory=200Mi, requestsCpu=20m, requestsMemory=32Mi
+  disabled                                            : disable service deployment; default: all
 
 example:
   % ./bin/$(basename ${0}) bootstrap build install:mds test:integration
@@ -208,10 +214,10 @@ bootstrap() {
 build() {
   check ${FUNCNAME[0]}
 
-  for mi in $(oq -i yaml -r '.apis | keys[]' ./helm/mds/values.yaml); do
-    mi=$(docker images --filter=reference="${mi}" -q)
-    [ ${#mi} -ge 1 ] && docker rmi -f ${mi}
-  done; unset mi
+  for s in $(oq -i yaml -r '.apis | keys[]' ./helm/mds/values.yaml); do
+    si=$(docker images --filter=reference="${s}" -q)
+    [ ${#si} -ge 1 ] && docker rmi -f ${si}
+  done; unset s si
 
   yarn clean
   yarn
@@ -384,9 +390,9 @@ installMetrics() {
 }
 
 imageVersion() {
-  for mi in $(oq -i yaml -r '.apis | keys[]' ./helm/mds/values.yaml); do
-    is+="${is:+,}sets-mds+=apis.${mi}.version=$(docker images ${mi} --format {{.Tag}})"
-  done; unset mi
+  for s in $(oq -i yaml -r '.apis | keys[]' ./helm/mds/values.yaml); do
+    is+="${is:+,}sets-mds+=apis.${s}.version=$(docker images ${s} --format {{.Tag}})"
+  done; unset s mi
 
   echo ${is}
 }
@@ -776,6 +782,25 @@ configure() {
   fi
 }
 
+preset() {
+  for p in ${@}; do
+    case ${p} in
+      disable)
+        for s in $(oq -i yaml -r '.apis | keys[]' ./helm/mds/values.yaml); do
+          is+="${is:+,}sets-mds+=apis.${s}.enabled=false"
+        done; unset s;;
+      local)
+        is+="${is:+,}sets-mds+=resourcesLimitsCpu=200m,sets-mds+=resourcesLimitsMemory=200Mi,sets-mds+=resourcesRequestsCpu=20m,sets-mds+=resourcesRequestsMemory=32Mi";;
+      minimal)
+        preset $(normalize "disable,local")
+        configs[sets-mds]=${configs[sets-mds]//apis.mds-agency.enabled=false/apis.mds-agency.enabled=true};;
+    esac
+  done; unset p
+
+  [ ${#is} -ge 1 ] && configure ${is}
+  unset is
+}
+
 [[ ${#} == 0 ]] && usage
 [[ ! -d ${configs[workdir]} ]] && mkdir -p ${configs[workdir]}
 check $(basename ${0})
@@ -807,6 +832,7 @@ for arg in "${@}"; do
     invoke install "$(normalize ${arg})";;
     help) usage;;
     --configure:* | configure:* | -c:*) configure "$(echo ${arg} | cut -d ':' -f 2-)";;
+    --preset:* | preset:* | -p:*) preset "$(normalize ${arg})";;
     *) usage "unknown command: ${arg}"
   esac
 done; unset arg


### PR DESCRIPTION
provide the ability to deploy against a preconfigured (aka presets) configuration option, examples being: agency only, minimal cpu/memory, etc.

test:

`% ./bin/mdsctl -p:minimal install:mds`

verify:

the only pods running should be: mds-agency, postgresql and redis

`% kubectl get pods -n mds`

note:

all former supported configurations exist and overlay presets, eg to additionally run mds-provider consider:

`% ./bin/mdsctl -p:minimal -c:sets-mds+=sets-mds=aps.mds-provider.enabled=true install:mds`
## PR Checklist

 - [ ] simple searchable title - `[mds-db] Add PG env var`, `[config] Fix eslint config`
 - [ ] briefly describe the changes in this PR
 - [ ] mark as draft if should not be merged
 - [ ] write tests for all new functionality

## Impacts
- [ ] Provider
- [ ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


