### PR TITLE
Syntax corrections from the OMF repo move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
-# Overview
+# Mobility Data Specification
+
+The Mobility Data Specification (**MDS**), a project of the [Open Mobility Foundation](http://www.openmobilityfoundation.org) (OMF),
+is a set of Application Programming Interfaces (APIs) focused on dockless e-scooters, bicycles and carshare. Inspired by projects
+like [GTFS](https://developers.google.com/transit/gtfs/reference/) and [GBFS](https://github.com/NABSA/gbfs), the goals of MDS are
+to provide a standardized way for municipalities or other regulatory agencies to ingest, compare and analyze data from mobility
+service providers, and to give municipalities the ability to express regulation in machine-readable formats.
+
+**MDS** helps cities interact with companies who operate dockless scooters, bicycles and carshare in the public right-of-way. MDS
+is a key piece of digital infrastructure that supports the effective implementation of mobility policies in cities around the world.
+
+**MDS** is an open-source project. It was originally created by the [Los Angeles Department of Transportation](http://ladot.io) (LADOT).
+In November 2019, stewardship of MDS and the ownership of this repository was transferred to the Open Mobility Foundation. GitHub
+automatically redirects any links to this repository in the `CityOfLosAngeles` organization to the `openmobilityfoundation` instead.
+MDS continues to be used by LADOT and many other municipalities.
+
+# Overview MDS-CORE
 
 Repo for LADOT MDS implementation for contribution to the Open Mobility Foundation.  It represents what is currently up and running for Los Angeles production MDS as well as new features under development.  Includes the following:
 

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -90,7 +90,7 @@ function api(app: express.Express): express.Express {
 
   /**
    * Endpoint to register vehicles
-   * See {@link https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency#vehicle---register Register}
+   * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle---register Register}
    */
   app.post(pathsFor('/vehicles'), registerVehicle)
 
@@ -109,13 +109,13 @@ function api(app: express.Express): express.Express {
 
   /**
    * Endpoint to submit vehicle events
-   * See {@link https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency#vehicle---event Events}
+   * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle---event Events}
    */
   app.post(pathsFor('/vehicles/:device_id/event'), validateDeviceId, submitVehicleEvent)
 
   /**
    * Endpoint to submit telemetry
-   * See {@link https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency#vehicles---update-telemetry Telemetry}
+   * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicles---update-telemetry Telemetry}
    */
   app.post(pathsFor('/vehicles/telemetry'), submitVehicleTelemetry)
 


### PR DESCRIPTION
References issue [#386](https://github.com/openmobilityfoundation/mobility-data-specification/issues/386).

## PR Checklist

These syntax corrections are required as the result of the repository move from the CityofLosAngeles github organization to the OpenMobilityFoundation.

There are still references to Service Areas. I don't know enough about the code yet to make recommendations. I have created issue [#239](https://github.com/openmobilityfoundation/mds-core/issues/239) for a maintainer to take a closer look.

## Impacts
- [ ] Provider
- [X ] Agency
- [ ] Audit
- [ ] Policy
- [ ] Compliance
- [ ] Daily
- [ ] Native
- [ ] Policy Author


