### PR TITLE
Doc link cleanup 1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,18 +1,24 @@
 # How To Contribute
 
-The following is a set of guidelines for contributing to this project. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines and rules for contributing to this project. These come from the OMF organization.
 
-#### Table of Contents
+## Contributing Guidelines
 
-[Code of Conduct](#code-of-conduct)
-
-[Development Dependencies](#development-dependencies)
+Please read the [Contributing Guidelines](https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/CONTRIBUTING.md) if you would like to contribute.
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the Code of Conduct from the [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This project and everyone participating in it is governed by the [Code of Conduct](https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/CODE_OF_CONDUCT.md).
 
 By participating, you are expected to uphold this code.
+
+## License
+
+Use of this code is governed by the [Licensing Agreement](https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/LICENSE).
+
+## Release Guidelines
+
+Adminsitrators of this repository follow the [MDS Release Guidelines](https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/ReleaseGuidelines.md)
 
 ## Development Dependencies
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The included code represents what is currently up and running for Los Angeles as
 * Development versions of mds-audit, mds-policy, and mds-compliance
 * MDS logging (mds-logger), daily metrics (mds-daily) and Google sheet reporting app for technical compliance.
 
-## Contributing, Code of Coduct, Licensing
+# Contributing, Code of Coduct, Licensing
 
 Read the [CONTRIBUTING.md](.github/CONTRIBUTING.md) document for rules and guidelines on contribution, code of conduct, license, development dependencies, and release guidelines.
 
-## Contents
+# Contents
 
 ### Stable Content
 #### APIs

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The included code represents what is currently up and running for Los Angeles as
 * Development versions of mds-audit, mds-policy, and mds-compliance
 * MDS logging (mds-logger), daily metrics (mds-daily) and Google sheet reporting app for technical compliance.
 
+## Contributing, Code of Coduct, Licensing
+
+Read the [CONTRIBUTING.md](.github/CONTRIBUTING.md) document for rules and guidelines on contribution, code of conduct, license, development dependencies, and release guidelines.
+
 ## Contents
 
 ### Stable Content
@@ -321,6 +325,3 @@ Display the complete set of operations:
 
 To commit code, you will need the pre-commit tool, which can be installed via `brew install pre-commit`.  For more information, see [SECURITY.md](.github/SECURITY.md)
 
-## Contributing
-
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
-# Overview
+# Introduction
 
-Repo for LADOT MDS implementation for contribution to the Open Mobility Foundation.  It represents what is currently up and running for Los Angeles production MDS as well as new features under development.
+The `mds-core` repo contains a deployable reference implementation for working with MDS data. It is a beta release meant for testing by cities and other entities to gather feedback and improve the product.
+
+`mds-core` is... 
+- a reference MDS implementation usable by cities 
+- on-ramp for developers joining MDS ecosystem 
+- a tool for validating software implementations and data 
+
+`mds-core` is not... 
+- the only implementation of MDS 
+- where the specification is officially defined
+- a place to define local policies or performance metrics 
+- a cloud service that will be operated by the OMF 
+
+See the `mds-core` [Github Wiki](https://github.com/openmobilityfoundation/mds-core/wiki) for more details and help.
+
+The [Mobility Data Specification](https://github.com/openmobilityfoundation/mobility-data-specification/) (MDS), a project of the [Open Mobility Foundation](http://www.openmobilityfoundation.org) (OMF) focused on dockless e-scooters, bicycles and carshare. 
+
+# Overview of MDS-CORE
+
+The included code represents what is currently up and running for Los Angeles as well as new features under development.  Includes the following:
+
+* A current LADOT implementation of all MDS endpoints
+* Development versions of mds-audit, mds-policy, and mds-compliance
+* MDS logging (mds-logger), daily metrics (mds-daily) and Google sheet reporting app for technical compliance.
 
 ## Contents
 

--- a/packages/mds-agency/api.ts
+++ b/packages/mds-agency/api.ts
@@ -1,17 +1,6 @@
 /*
-    Copyright 2019 City of Los Angeles.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+    LICENSE
+    https://github.com/openmobilityfoundation/mobility-data-specification/blob/master/LICENSE
  */
 
 import express from 'express'
@@ -88,7 +77,7 @@ function api(app: express.Express): express.Express {
 
   /**
    * Endpoint to register vehicles
-   * See {@link https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency#vehicle---register Register}
+   * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle---register Register}
    */
   app.post(pathsFor('/vehicles'), registerVehicle)
 
@@ -107,13 +96,13 @@ function api(app: express.Express): express.Express {
 
   /**
    * Endpoint to submit vehicle events
-   * See {@link https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency#vehicle---event Events}
+   * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle---event Events}
    */
   app.post(pathsFor('/vehicles/:device_id/event'), validateDeviceId, submitVehicleEvent)
 
   /**
    * Endpoint to submit telemetry
-   * See {@link https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency#vehicles---update-telemetry Telemetry}
+   * See {@link https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicles---update-telemetry Telemetry}
    */
   app.post(pathsFor('/vehicles/telemetry'), submitVehicleTelemetry)
 


### PR DESCRIPTION
## 📚 Purpose
Cleaning up documentation, adding context, adding required documents and language

## 👌 Resolves:
- #239 

## 📦 Impacts:
Documentation only, not code

## ✅ PR Checklist
- Push to dev
- Delete _doc-link-cleanup-1_ and _docs/omf-release-0.1_ since this PR covers both
- Push changes to master
- Ensure new development uses _dev_ as a starting point.